### PR TITLE
Switch build tests to slc6 based docker image and test compiling with scram+different CMSSW versions

### DIFF
--- a/.install-dependencies.sh
+++ b/.install-dependencies.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-
-# Install Root
-wget http://www-ekp.physik.uni-karlsruhe.de/~sieber/root_5.34.07-1_amd64.deb || exit 1
-sudo dpkg -i root_5.34.07-1_amd64.deb || exit 1
-echo "/usr/local/lib" | sudo tee -a /etc/ld.so.conf
-echo "/usr/local/lib/root" | sudo tee -a /etc/ld.so.conf
-sudo ldconfig || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,14 @@
-# travis config for Kappa
-
 sudo: required
 language: cpp
-notifications:
-  email:
-    on_success: never # default: change
-    on_failure: never # default: always
+services:
+  - docker
+env:
+  - TEST_CMSSW_VERSION: CMSSW_5_3_29
+  - TEST_CMSSW_VERSION: CMSSW_7_2_5
+  - TEST_CMSSW_VERSION: CMSSW_7_4_2
 compiler:
   - gcc
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.8
-    - g++-4.8
-    - clang
 before_install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-  - sudo add-apt-repository --yes ppa:boost-latest/ppa
-  - sudo apt-get -qq update
-  - sudo apt-get install libboost1.54-all-dev
-  - ./.install-dependencies.sh
-install: 
-  - make -C DataFormats/test
-script: make -C DataFormats/test
+  - docker pull claria/cvmfs-cms
+script:
+  - docker run --privileged -e TEST_CMSSW_VERSION=${TEST_CMSSW_VERSION} -v ${TRAVIS_BUILD_DIR}:/home/travis claria/cvmfs-cms /bin/bash -c "cd /home/; /home/travis/test_build.sh"

--- a/DataFormats/BuildFile.xml
+++ b/DataFormats/BuildFile.xml
@@ -4,6 +4,7 @@
 <flags REM_CXXFLAGS="-fipa-pta"/>
 <use name="rootrflx" />
 <use name="rootmath" />
+<use name="boost" />
 
 <export>
 	<use name="rootrflx" />

--- a/DataFormats/BuildFile.xml
+++ b/DataFormats/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="rootrflx" />
 <use name="rootmath" />
 <use name="boost" />
+<use name="boost_system" />
 
 <export>
 	<use name="rootrflx" />

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+/etc/cvmfs/run-cvmfs.sh
+
+export SCRAM_ARCH=slc6_amd64_gcc481
+export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+
+mkdir -p /home/build && cd /home/build
+
+
+. $VO_CMS_SW_DIR/cmsset_default.sh
+scram project ${TEST_CMSSW_VERSION}
+
+cd ${TEST_CMSSW_VERSION}
+
+cmsenv
+
+cd src/
+
+mkdir Kappa
+mv /home/travis/* Kappa/
+
+echo "# ================= #"
+echo "# Building in CMSSW #"
+echo "# ================= #"
+
+scram b -v -j 2 || exit 1
+
+echo "# =================== #"
+echo "# Building standalone #"
+echo "# =================== #"
+
+echo $CMSSW_BASE
+make -C Kappa/DataFormats/test -j2 || exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -18,7 +18,7 @@ cmsenv
 cd src/
 
 mkdir Kappa
-mv /home/travis/* Kappa/
+cp -r /home/travis/* Kappa/
 
 echo "# ================= #"
 echo "# Building in CMSSW #"


### PR DESCRIPTION
Switch to slc6-docker with cvmfs. 
Test building Kappa standalone and with different CMSSW versions.
The versions to be tested can just be adapted in the .travis.yml file.
