### PR TITLE
Generator flags

### DIFF
--- a/DataFormats/interface/KParticle.h
+++ b/DataFormats/interface/KParticle.h
@@ -130,13 +130,16 @@ struct KGenParticle : public KParticle
 			return -1;
 	}
 
-	inline bool isPromptFinalState()                           const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::isPrompt))); };
-	inline bool fromHardProcessFinalState()                    const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::fromHardProcess))); };
-	inline bool isDirectPromptTauDecayProductFinalState()      const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::isDirectPromptTauDecayProduct))); };
-	inline bool isDirectHardProcessTauDecayProductFinalState() const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::isDirectHardProcessTauDecayProduct))); };
-	inline bool isPromptDecayed()        const { return ((particleinfo & (1 << KGenStatusFlags::isPrompt)) && (particleinfo & (1 << KGenStatusFlags::isDecayedLeptonHadron))); };
-	inline bool isHardProcess()          const { return ((particleinfo & (1 << KGenStatusFlags::isHardProcess))); };
-	inline bool fromHardProcessDecayed() const { return ((particleinfo & (1 << KGenStatusFlags::isDecayedLeptonHadron)) && (particleinfo & (1 << KGenStatusFlags::fromHardProcess))); };
+	inline bool isPrompt()           const { return ((particleinfo & (1 << KGenStatusFlags::isPrompt))); };
+	inline bool isPromptFinalState() const { return ((particleinfo & (1 << KGenStatusFlags::isPrompt)) && status() == 1); };
+	inline bool isPromptDecayed()    const { return ((particleinfo & (1 << KGenStatusFlags::isPrompt)) && (particleinfo & (1 << KGenStatusFlags::isDecayedLeptonHadron))); };
+	inline bool isDirectPromptTauDecayProduct()                const { return ((particleinfo & (1 << KGenStatusFlags::isDirectPromptTauDecayProduct))); };
+	inline bool isDirectPromptTauDecayProductFinalState()      const { return ((particleinfo & (1 << KGenStatusFlags::isDirectPromptTauDecayProduct)) && status() == 1); };
+	inline bool isDirectHardProcessTauDecayProduct()           const { return ((particleinfo & (1 << KGenStatusFlags::isDirectHardProcessTauDecayProduct))); };
+	inline bool isDirectHardProcessTauDecayProductFinalState() const { return ((particleinfo & (1 << KGenStatusFlags::isDirectHardProcessTauDecayProduct)) && status() == 1); };
+	inline bool isHardProcess()             const { return ((particleinfo & (1 << KGenStatusFlags::isHardProcess))); };
+	inline bool fromHardProcessFinalState() const { return ((particleinfo & (1 << KGenStatusFlags::fromHardProcess)) && status() == 1); };
+	inline bool fromHardProcessDecayed()    const { return ((particleinfo & (1 << KGenStatusFlags::fromHardProcess)) && (particleinfo & (1 << KGenStatusFlags::isDecayedLeptonHadron))); };
 };
 typedef std::vector<KGenParticle> KGenParticles;
 

--- a/DataFormats/interface/KParticle.h
+++ b/DataFormats/interface/KParticle.h
@@ -39,20 +39,8 @@ struct KParticle : public KLV
 	/// PDG-ID of the particle (signed)
 	int pdgId() const
 	{
-		return sign() * static_cast<int>(particleinfo & KParticlePdgIdMask);
-	}
-	int pdgId_v2() const
-	{
 		return sign() * static_cast<int>(particleid);
 	}
-
-	inline bool isPromptFinalState()                           const { return (status() == 1 && (particleinfo & (1 << 0))); };
-	inline bool fromHardProcessFinalState()                    const { return (status() == 1 && (particleinfo & (1 << 8))); };
-	inline bool isDirectPromptTauDecayProductFinalState()      const { return (status() == 1 && (particleinfo & (1 << 5))); };
-	inline bool isDirectHardProcessTauDecayProductFinalState() const { return (status() == 1 && (particleinfo & (1 << 10))); };
-	inline bool isPromptDecayed()        const { return ((particleinfo & (1 << 0)) && (particleinfo & (1 << 1))); };
-	inline bool isHardProcess()          const { return ((particleinfo & (1 << 7))); };
-	inline bool fromHardProcessDecayed() const { return ((particleinfo & (1 << 1)) && (particleinfo & (1 << 8))); };
 
 	/// particle charge multiplied by 3 (for integer comparisons)
 	/** e.g. 2 for up-quark, -3 for electron
@@ -104,6 +92,23 @@ struct KParticle : public KLV
 typedef std::vector<KParticle> KParticles;
 
 
+/// from DataFormats/HepMCCandidate/interface/GenStatusFlags.h
+namespace KGenStatusFlags { enum Type
+{
+	isPrompt                           = 0,
+	isDecayedLeptonHadron              = 1,
+	isTauDecayProduct                  = 2,
+	isPromptTauDecayProduct            = 3,
+	isDirectTauDecayProduct            = 4,
+	isDirectPromptTauDecayProduct      = 5,
+	isDirectHadronDecayProduct         = 6,
+	isHardProcess                      = 7,
+	fromHardProcess                    = 8,
+	isHardProcessTauDecayProduct       = 9,
+	isDirectHardProcessTauDecayProduct = 10
+};
+}
+
 /// Generator particle
 struct KGenParticle : public KParticle
 {
@@ -124,6 +129,14 @@ struct KGenParticle : public KParticle
 		else
 			return -1;
 	}
+
+	inline bool isPromptFinalState()                           const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::isPrompt))); };
+	inline bool fromHardProcessFinalState()                    const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::fromHardProcess))); };
+	inline bool isDirectPromptTauDecayProductFinalState()      const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::isDirectPromptTauDecayProduct))); };
+	inline bool isDirectHardProcessTauDecayProductFinalState() const { return (status() == 1 && (particleinfo & (1 << KGenStatusFlags::isDirectHardProcessTauDecayProduct))); };
+	inline bool isPromptDecayed()        const { return ((particleinfo & (1 << KGenStatusFlags::isPrompt)) && (particleinfo & (1 << KGenStatusFlags::isDecayedLeptonHadron))); };
+	inline bool isHardProcess()          const { return ((particleinfo & (1 << KGenStatusFlags::isHardProcess))); };
+	inline bool fromHardProcessDecayed() const { return ((particleinfo & (1 << KGenStatusFlags::isDecayedLeptonHadron)) && (particleinfo & (1 << KGenStatusFlags::fromHardProcess))); };
 };
 typedef std::vector<KGenParticle> KGenParticles;
 

--- a/DataFormats/interface/KParticle.h
+++ b/DataFormats/interface/KParticle.h
@@ -14,7 +14,7 @@ const unsigned int KParticleStatusPosition = 24;
 const unsigned int KParticleSignMask   =  (unsigned int)1 << KParticleSignPosition;
 const unsigned int KParticleCustomMask =  (unsigned int)15 << KParticleCustomPosition;  // to be removed
 const unsigned int KParticleStatusMask =  (unsigned int)127 << KParticleStatusPosition;
-// const unsigned int KParticlePdgIdMask  = ((unsigned int)1 << KParticleStatusPosition) - (unsigned int)1;
+const unsigned int KParticlePdgIdMask  = ((unsigned int)1 << KParticleStatusPosition) - (unsigned int)1;
 
 
 /// Particle base class for generator particles or candidates
@@ -39,8 +39,11 @@ struct KParticle : public KLV
 	/// PDG-ID of the particle (signed)
 	int pdgId() const
 	{
+		return sign() * static_cast<int>(particleinfo & KParticlePdgIdMask);
+	}
+	int pdgId_v2() const
+	{
 		return sign() * static_cast<int>(particleid);
-// 		return sign() * static_cast<int>(particleinfo & KParticlePdgIdMask);
 	}
 
 	inline bool isPromptFinalState()                           const { return (status() == 1 && (particleinfo & (1 << 0))); };

--- a/Producers/interface/KGenParticleProducer.h
+++ b/Producers/interface/KGenParticleProducer.h
@@ -74,11 +74,11 @@ protected:
 		out.particleinfo |= (statusFlags.isDirectHardProcessTauDecayProduct() << 10);
 #endif
 
-		if (in.pdgId() != out.pdgId())
+		if (in.pdgId() != out.pdgId_v2())
 			std::cout << "The pdgId is not skimmed correctly! "
 					  << "in=" << in.pdgId() << ", out=" << out.pdgId()
 					  << std::endl << std::flush;
-		assert(in.pdgId() == out.pdgId());
+		assert(in.pdgId() == out.pdgId_v2());
 
 	}
 

--- a/Producers/interface/KGenParticleProducer.h
+++ b/Producers/interface/KGenParticleProducer.h
@@ -51,7 +51,6 @@ protected:
 		unsigned int id = (in.pdgId() < 0) ? -in.pdgId() : in.pdgId();
 		out.particleid = id;
 		out.particleinfo = ((in.status() % 128) << KParticleStatusPosition);
-// 		out.particleinfo = id | ((in.status() % 128) << KParticleStatusPosition);
 		if (in.status() >= 111)  // Pythia 8 maximum
 			out.particleinfo |= (127 << KParticleStatusPosition);
 		if (in.pdgId() < 0)
@@ -60,25 +59,25 @@ protected:
 
 #if (CMSSW_MAJOR_VERSION > 7) || (CMSSW_MAJOR_VERSION == 7 && CMSSW_MINOR_VERSION >= 4)
 		// generator-independent flags
-		reco::GenStatusFlags statusFlags = (dynamic_cast<const reco::GenParticle*>(&in))->statusFlags();
-		out.particleinfo |= (statusFlags.isPrompt()                           << 0);
-		out.particleinfo |= (statusFlags.isDecayedLeptonHadron()              << 1);
-		out.particleinfo |= (statusFlags.isTauDecayProduct()                  << 2);
-		out.particleinfo |= (statusFlags.isPromptTauDecayProduct()            << 3);
-		out.particleinfo |= (statusFlags.isDirectTauDecayProduct()            << 4);
-		out.particleinfo |= (statusFlags.isDirectPromptTauDecayProduct()      << 5);
-		out.particleinfo |= (statusFlags.isDirectHadronDecayProduct()         << 6);
-		out.particleinfo |= (statusFlags.isHardProcess()                      << 7);
-		out.particleinfo |= (statusFlags.fromHardProcess()                    << 8);
-		out.particleinfo |= (statusFlags.isHardProcessTauDecayProduct()       << 9);
-		out.particleinfo |= (statusFlags.isDirectHardProcessTauDecayProduct() << 10);
+		reco::GenStatusFlags flags = (dynamic_cast<const reco::GenParticle*>(&in))->statusFlags();
+		out.particleinfo |= (flags.isPrompt()                           << KGenStatusFlags::isPrompt);
+		out.particleinfo |= (flags.isDecayedLeptonHadron()              << KGenStatusFlags::isDecayedLeptonHadron);
+		out.particleinfo |= (flags.isTauDecayProduct()                  << KGenStatusFlags::isTauDecayProduct);
+		out.particleinfo |= (flags.isPromptTauDecayProduct()            << KGenStatusFlags::isPromptTauDecayProduct);
+		out.particleinfo |= (flags.isDirectTauDecayProduct()            << KGenStatusFlags::isDirectTauDecayProduct);
+		out.particleinfo |= (flags.isDirectPromptTauDecayProduct()      << KGenStatusFlags::isDirectPromptTauDecayProduct);
+		out.particleinfo |= (flags.isDirectHadronDecayProduct()         << KGenStatusFlags::isDirectHadronDecayProduct);
+		out.particleinfo |= (flags.isHardProcess()                      << KGenStatusFlags::isHardProcess);
+		out.particleinfo |= (flags.fromHardProcess()                    << KGenStatusFlags::fromHardProcess);
+		out.particleinfo |= (flags.isHardProcessTauDecayProduct()       << KGenStatusFlags::isHardProcessTauDecayProduct);
+		out.particleinfo |= (flags.isDirectHardProcessTauDecayProduct() << KGenStatusFlags::isDirectHardProcessTauDecayProduct);
 #endif
 
-		if (in.pdgId() != out.pdgId_v2())
+		if (in.pdgId() != out.pdgId())
 			std::cout << "The pdgId is not skimmed correctly! "
 					  << "in=" << in.pdgId() << ", out=" << out.pdgId()
 					  << std::endl << std::flush;
-		assert(in.pdgId() == out.pdgId_v2());
+		assert(in.pdgId() == out.pdgId());
 
 	}
 

--- a/Producers/interface/KGenParticleProducer.h
+++ b/Producers/interface/KGenParticleProducer.h
@@ -49,12 +49,30 @@ protected:
 		}
 
 		unsigned int id = (in.pdgId() < 0) ? -in.pdgId() : in.pdgId();
-		out.particleinfo = id | ((in.status() % 128) << KParticleStatusPosition);
+		out.particleid = id;
+		out.particleinfo = ((in.status() % 128) << KParticleStatusPosition);
+// 		out.particleinfo = id | ((in.status() % 128) << KParticleStatusPosition);
 		if (in.status() >= 111)  // Pythia 8 maximum
 			out.particleinfo |= (127 << KParticleStatusPosition);
 		if (in.pdgId() < 0)
 			out.particleinfo |= KParticleSignMask;
 		out.daughterIndices = daughters;
+
+#if (CMSSW_MAJOR_VERSION > 7) || (CMSSW_MAJOR_VERSION == 7 && CMSSW_MINOR_VERSION >= 4)
+		// generator-independent flags
+		reco::GenStatusFlags statusFlags = (dynamic_cast<const reco::GenParticle*>(&in))->statusFlags();
+		out.particleinfo |= (statusFlags.isPrompt()                           << 0);
+		out.particleinfo |= (statusFlags.isDecayedLeptonHadron()              << 1);
+		out.particleinfo |= (statusFlags.isTauDecayProduct()                  << 2);
+		out.particleinfo |= (statusFlags.isPromptTauDecayProduct()            << 3);
+		out.particleinfo |= (statusFlags.isDirectTauDecayProduct()            << 4);
+		out.particleinfo |= (statusFlags.isDirectPromptTauDecayProduct()      << 5);
+		out.particleinfo |= (statusFlags.isDirectHadronDecayProduct()         << 6);
+		out.particleinfo |= (statusFlags.isHardProcess()                      << 7);
+		out.particleinfo |= (statusFlags.fromHardProcess()                    << 8);
+		out.particleinfo |= (statusFlags.isHardProcessTauDecayProduct()       << 9);
+		out.particleinfo |= (statusFlags.isDirectHardProcessTauDecayProduct() << 10);
+#endif
 
 		if (in.pdgId() != out.pdgId())
 			std::cout << "The pdgId is not skimmed correctly! "

--- a/Producers/interface/KGenParticleProducer.h
+++ b/Producers/interface/KGenParticleProducer.h
@@ -59,7 +59,7 @@ protected:
 
 #if (CMSSW_MAJOR_VERSION > 7) || (CMSSW_MAJOR_VERSION == 7 && CMSSW_MINOR_VERSION >= 4)
 		// generator-independent flags
-		reco::GenStatusFlags flags = (dynamic_cast<const reco::GenParticle*>(&in))->statusFlags();
+		reco::GenStatusFlags flags = (static_cast<const reco::GenParticle*>(&in))->statusFlags();
 		out.particleinfo |= (flags.isPrompt()                           << KGenStatusFlags::isPrompt);
 		out.particleinfo |= (flags.isDecayedLeptonHadron()              << KGenStatusFlags::isDecayedLeptonHadron);
 		out.particleinfo |= (flags.isTauDecayProduct()                  << KGenStatusFlags::isTauDecayProduct);

--- a/Producers/interface/KLHEProducer.h
+++ b/Producers/interface/KLHEProducer.h
@@ -38,7 +38,8 @@ protected:
 
 			// particle id and status
 			unsigned int id = (in.hepeup().IDUP[i] < 0) ? -in.hepeup().IDUP[i] : in.hepeup().IDUP[i];
-			p.particleinfo = id | ((in.hepeup().ISTUP[i] % 4) << KParticleStatusPosition);
+			p.particleid = id;
+			p.particleinfo = ((in.hepeup().ISTUP[i] % 4) << KParticleStatusPosition);
 			if (in.hepeup().IDUP[i] < 0)
 				p.particleinfo |= KParticleSignMask;
 

--- a/Producers/interface/KPFCandidateProducer.h
+++ b/Producers/interface/KPFCandidateProducer.h
@@ -26,7 +26,7 @@ public:
 	static void fillPFCandidate(const SingleInputType &in, SingleOutputType &out)
 	{
 		copyP4(in, out.p4);
-		out.particleinfo = (in.pdgId() < 0) ? -in.pdgId() : in.pdgId();
+		out.particleid = (in.pdgId() < 0) ? -in.pdgId() : in.pdgId();
 		if (in.pdgId() < 0)
 			out.particleinfo |= KParticleSignMask;
 		out.deltaP = in.deltaP();

--- a/Producers/interface/KPackedPFCandidateProducer.h
+++ b/Producers/interface/KPackedPFCandidateProducer.h
@@ -21,7 +21,7 @@ public:
 	virtual void fillSingle(const SingleInputType &in, SingleOutputType &out)
 	{
 		copyP4(in, out.p4);
-		out.particleinfo = (in.pdgId() < 0) ? -in.pdgId() : in.pdgId();
+		out.particleid = (in.pdgId() < 0) ? -in.pdgId() : in.pdgId();
 		if (in.pdgId() < 0)
 			out.particleinfo |= KParticleSignMask;
 		//out.deltaP = in.deltaP(); // all not included in packedPFCandidates


### PR DESCRIPTION
Dear Kappa users,

I branched this off the current "dictchanges" branch in order to put down in code the inclusion in Kappa of generator-independent status flags, which are already used by other groups
DataFormats/HepMCCandidate/interface/GenParticle.h
DataFormats/HepMCCandidate/interface/GenStatusFlags.h

This has quite some importance for the Higgs analysis, since these flags are used to split the inclusive Drell-Yan sample in the different subcomponents (ZTT/ZL/ZJ).

From the Kappa dataformats point of view, the current proposal consists in saving the pdgId in a separate variable ("particleid"), allowing to use the part of the "particleinfo" bitset which is left free for the inclusion of the new flags.
I tested that with the new dictionary the methods sign() and status() work exactly as before (this is expected, since they are not affected by any change), and that the methods pdgId() and charge() give the same results as well.
I just produced a skim on a sync SUSY sample, and I will now test if using the current status of the Kappa branch already gives all the informations that we need, in order to propagate this down to the final Artus ntuple.
