### PR TITLE
renaming collections in a consistent way (requires changes in analyses based on it)

### DIFF
--- a/Producers/python/KTuple_cff.py
+++ b/Producers/python/KTuple_cff.py
@@ -233,7 +233,7 @@ kappaTupleDefaultsBlock = cms.PSet(
 		whitelist = cms.vstring("slimmedMETs"),
 		blacklist = cms.vstring(),
 
-		rename = cms.vstring("slimmedMETs => met"),
+		rename = cms.vstring("slimmedMETs => met", "patPFMet => met"),
 		rename_whitelist= cms.vstring(),
 		rename_blacklist = cms.vstring(),
 	),
@@ -495,7 +495,7 @@ kappaTupleDefaultsBlock = cms.PSet(
 		blacklist = cms.vstring(".*Tau.*", "recoPFJets_pfJets.*kappaSkim", "Jets(Iso)?QG", ".*SubJets.*"),
 
 		rename = cms.vstring(
-			"(slimmedJetsAK8)|(slimmed) => (?1ak8PFJets)(?2ak5PF)"
+			"(slimmedJetsAK8)|(slimmed) => (?1ak8PFJets)(?2ak4PF)"
 		),
 		rename_whitelist= cms.vstring(),
 		rename_blacklist = cms.vstring(),


### PR DESCRIPTION
Hi Kappa users,

I propose to do this two changes of names for the next skim campaign to streamline the naming. It should not matter if a MET is produced from PAT.

On the other hand, slimmedJets are not ak5. We should at least call them "ak4" if not even "ak4chs" or just "jets". What do you think?
