### PR TITLE
First look into making Kappa CMSSW_7_6 compatible, NOT ment for merging

### DIFF
--- a/Producers/interface/KBaseMatchingProducer.h
+++ b/Producers/interface/KBaseMatchingProducer.h
@@ -7,6 +7,8 @@
 #define KAPPA_MATCHINGPRODUCER_H
 
 #include "KBaseProducer.h"
+
+#include <FWCore/Framework/interface/EDProducer.h>
 #include <FWCore/Utilities/interface/InputTag.h>
 #include <Kappa/DataFormats/interface/Kappa.h>
 
@@ -14,8 +16,8 @@ template<typename Tout>
 class KBaseMatchingProducer : public KBaseProducerWP
 {
 public:
-	KBaseMatchingProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, const std::string &producerName) :
-		KBaseProducerWP(cfg, _event_tree, _run_tree, producerName),
+	KBaseMatchingProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, const std::string &producerName, edm::ConsumesCollector && consumescollector) :
+		KBaseProducerWP(cfg, _event_tree, _run_tree, producerName, std::forward<edm::ConsumesCollector>(consumescollector)),
 		event_tree(_event_tree), matchingCounter(0), producerLabel(producerName),
 		viManual(cfg.getParameter<std::vector<edm::InputTag> >("manual")),
 
@@ -36,14 +38,42 @@ public:
 
 	virtual bool onFirstEvent(const edm::Event &event, const edm::EventSetup &setup)
 	{
-		addPSetRequests(event, setup);
-		addRegExRequests(event, setup);
+		//addPSetRequests(event, setup);
+		//addRegExRequests(event, setup);
 		if (this->verbosity > 0)
 			std::cout << "KBaseMatchingProducer::onFirstEvent : Accepted number of matched products: " << matchingCounter << std::endl;
 		return KBaseProducerWP::onFirstEvent(event, setup);
 	}
+	
+
 
 protected:
+	bool addPSetRequests()
+	{
+		if (verbosity > 0)
+			std::cout << "Requesting entries: ";
+
+		const edm::ParameterSet &psBase = this->psBase;
+		std::vector<std::string> names = psBase.getParameterNamesForType<edm::ParameterSet>();
+
+		for (size_t i = 0; i < names.size(); ++i)
+		{
+			if (verbosity > 0)
+				std::cout << "\"" << names[i] << "\" ";
+			const edm::ParameterSet pset = psBase.getParameter<edm::ParameterSet>(names[i]);
+			// Notify about match
+			if (!onMatchingInput(names[i], names[i], pset, pset.getParameter<edm::InputTag>("src")))
+				return false;
+		}
+		if (verbosity > 0)
+			std::cout << std::endl;
+
+		if (verbosity > 0 && names.size() == 0)
+			std::cout << "Warning! A a PSet was requested but none found. Maybe a config file error?" << std::endl;
+
+		return true;
+	}
+
 	virtual bool onMatchingInput(const std::string targetName, const std::string inputName,
 		const edm::ParameterSet &pset, const edm::InputTag &tag)
 	{
@@ -75,32 +105,6 @@ private:
 
 	std::vector<std::string> vsMatched;
 	std::map<std::string, Tout*> bronchStorage;
-
-	bool addPSetRequests(const edm::Event &event, const edm::EventSetup &setup)
-	{
-		if (verbosity > 0)
-			std::cout << "Requesting entries: ";
-
-		const edm::ParameterSet &psBase = this->psBase;
-		std::vector<std::string> names = psBase.getParameterNamesForType<edm::ParameterSet>();
-
-		for (size_t i = 0; i < names.size(); ++i)
-		{
-			if (verbosity > 0)
-				std::cout << "\"" << names[i] << "\" ";
-			const edm::ParameterSet pset = psBase.getParameter<edm::ParameterSet>(names[i]);
-			// Notify about match
-			if (!onMatchingInput(names[i], names[i], pset, pset.getParameter<edm::InputTag>("src")))
-				return false;
-		}
-		if (verbosity > 0)
-			std::cout << std::endl;
-
-		if (verbosity > 0 && names.size() == 0)
-			std::cout << "Warning! A a PSet was requested but none found. Maybe a config file error?" << std::endl;
-
-		return true;
-	}
 
 	bool addRegExRequests(const edm::Event &event, const edm::EventSetup &setup)
 	{

--- a/Producers/interface/KBaseMultiLVProducer.h
+++ b/Producers/interface/KBaseMultiLVProducer.h
@@ -8,6 +8,7 @@
 #define KAPPA_MULTILVPRODUCER_H
 
 #include "KBaseMultiProducer.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 template<typename T>
 struct KLVSorter
@@ -28,8 +29,8 @@ protected:
 	typedef typename KBaseMultiProducer<Tin, Tout>::InputType::value_type SingleInputType;
 	typedef typename KBaseMultiProducer<Tin, Tout>::OutputType::value_type SingleOutputType;
 public:
-	KBaseMultiVectorProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, const std::string &producerName) :
-		KBaseMultiProducer<Tin, Tout>(cfg, _event_tree, _run_tree, producerName),
+	KBaseMultiVectorProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, const std::string &producerName, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<Tin, Tout>(cfg, _event_tree, _run_tree, producerName, std::forward<edm::ConsumesCollector>(consumescollector)),
 		maxN(cfg.getParameter<int>("maxN")),
 		firstObject(true) {}
 
@@ -85,8 +86,8 @@ template<typename Tin, typename Tout>
 class KBaseMultiLVProducer : public KBaseMultiVectorProducer<Tin, Tout>
 {
 public:
-	KBaseMultiLVProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, const std::string &producerName) :
-		KBaseMultiVectorProducer<Tin, Tout>(cfg, _event_tree, _run_tree, producerName),
+	KBaseMultiLVProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, const std::string &producerName, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiVectorProducer<Tin, Tout>(cfg, _event_tree, _run_tree, producerName, std::forward<edm::ConsumesCollector>(consumescollector)),
 		minPt(cfg.getParameter<double>("minPt")),
 		maxEta(cfg.getParameter<double>("maxEta")) {}
 

--- a/Producers/interface/KBaseProducer.h
+++ b/Producers/interface/KBaseProducer.h
@@ -11,6 +11,7 @@
 #include <FWCore/Framework/interface/LuminosityBlock.h>
 #include <FWCore/Framework/interface/Run.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 #include "../../DataFormats/interface/KInfo.h"
 
 // KBaseProducer is the base class for all producers
@@ -47,7 +48,7 @@ class KBaseProducerWP : public KBaseProducer
 {
 public:
 	virtual ~KBaseProducerWP() {};
-	KBaseProducerWP(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, const std::string &producerName);
+	KBaseProducerWP(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, const std::string &producerName, edm::ConsumesCollector && consumescollector);
 	void addProvenance(std::string oldName, std::string newName);
 
 protected:

--- a/Producers/interface/KBasicJetProducer.h
+++ b/Producers/interface/KBasicJetProducer.h
@@ -10,13 +10,14 @@
 #define KAPPA_BASICJETPRODUCER_H
 
 #include "KBaseMultiLVProducer.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 #include <DataFormats/JetReco/interface/PFJet.h>
 
 class KBasicJetProducer : public KBaseMultiLVProducer<reco::PFJetCollection, std::vector<KBasicJet> >
 {
 public:
-	KBasicJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<reco::PFJetCollection, KBasicJets>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KBasicJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<reco::PFJetCollection, KBasicJets>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "BasicJets"; }
 

--- a/Producers/interface/KBasicTauProducer.h
+++ b/Producers/interface/KBasicTauProducer.h
@@ -11,6 +11,7 @@
 
 #include "KBaseMultiLVProducer.h"
 #include "../../DataFormats/interface/KTrack.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 template<typename TTau, typename TTauDiscriminator, typename TProduct>
 // Note: We need to use std::vector here, not edm::View, because otherwise
@@ -21,8 +22,8 @@ template<typename TTau, typename TTauDiscriminator, typename TProduct>
 class KBasicTauProducer : public KBaseMultiLVProducer<std::vector<TTau>, TProduct>
 {
 public:
-	KBasicTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, const std::string &producerName) :
-		KBaseMultiLVProducer<std::vector<TTau>, TProduct>(cfg, _event_tree, _lumi_tree, producerName)
+	KBasicTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, const std::string &producerName, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<std::vector<TTau>, TProduct>(cfg, _event_tree, _lumi_tree, producerName, std::forward<edm::ConsumesCollector>(consumescollector))
 	{
 		const edm::ParameterSet &psBase = this->psBase;
 		std::vector<std::string> names = psBase.getParameterNamesForType<edm::ParameterSet>();

--- a/Producers/interface/KBasicTauProducer.h
+++ b/Producers/interface/KBasicTauProducer.h
@@ -46,6 +46,7 @@ public:
 			floatDiscrWhitelist[names[i]] = pset.getParameter< std::vector<std::string> >("floatDiscrWhitelist");
 			floatDiscrBlacklist[names[i]] = pset.getParameter< std::vector<std::string> >("floatDiscrBlacklist");
 			tauDiscrProcessName[names[i]] = pset.getParameter< std::string >("tauDiscrProcessName");
+			if(pset.existsAs<edm::InputTag>("vertexcollection")) consumescollector.consumes<reco::VertexCollection>(pset.getParameter<edm::InputTag>("vertexcollection"));
 		}
 	}
 

--- a/Producers/interface/KBeamSpotProducer.h
+++ b/Producers/interface/KBeamSpotProducer.h
@@ -8,13 +8,14 @@
 
 #include "KBaseMultiProducer.h"
 #include "../../DataFormats/interface/KBasic.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 #include <DataFormats/BeamSpot/interface/BeamSpot.h>
 
 class KBeamSpotProducer : public KBaseMultiProducer<reco::BeamSpot, KBeamSpot>
 {
 public:
-	KBeamSpotProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<reco::BeamSpot, KBeamSpot>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KBeamSpotProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<reco::BeamSpot, KBeamSpot>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 	virtual ~KBeamSpotProducer() {};
 
 	static const std::string getLabel() { return "BeamSpot"; }

--- a/Producers/interface/KCaloJetProducer.h
+++ b/Producers/interface/KCaloJetProducer.h
@@ -9,14 +9,15 @@
 #define KAPPA_CALOJETPRODUCER_H
 
 #include "KBaseMultiLVProducer.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 #include <DataFormats/JetReco/interface/CaloJet.h>
 #include <DataFormats/JetReco/interface/JetID.h>
 
 class KCaloJetProducer : public KBaseMultiLVProducer<reco::CaloJetCollection, KCaloJets>
 {
 public:
-	KCaloJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<reco::CaloJetCollection, KCaloJets>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KCaloJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<reco::CaloJetCollection, KCaloJets>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "CaloJets"; }
 

--- a/Producers/interface/KDataInfoProducer.h
+++ b/Producers/interface/KDataInfoProducer.h
@@ -29,7 +29,11 @@ public:
 		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree, std::forward<edm::ConsumesCollector>(consumescollector)),
 		currentRun(0),
 		lumiSource(cfg.getParameter<edm::InputTag>("lumiSource")),
-		isEmbedded(cfg.getParameter<bool>("isEmbedded")) {}
+		isEmbedded(cfg.getParameter<bool>("isEmbedded"))
+		{
+		    consumescollector.consumes<LumiSummary>(lumiSource);
+		    consumescollector.consumes<GenFilterInfo>(edm::InputTag("generator", "minVisPtFilter", "EmbeddedRECO"));
+		}
 
 	static const std::string getLabel() { return "DataInfo"; }
 

--- a/Producers/interface/KDataInfoProducer.h
+++ b/Producers/interface/KDataInfoProducer.h
@@ -8,6 +8,7 @@
 #define KAPPA_DATAINFOPRODUCER_H
 
 #include <DataFormats/Luminosity/interface/LumiSummary.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 #include "KInfoProducer.h"
 
 
@@ -24,8 +25,8 @@ template<typename Tmeta>
 class KDataInfoProducer : public KInfoProducer<Tmeta>
 {
 public:
-	KDataInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree),
+	KDataInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree, std::forward<edm::ConsumesCollector>(consumescollector)),
 		currentRun(0),
 		lumiSource(cfg.getParameter<edm::InputTag>("lumiSource")),
 		isEmbedded(cfg.getParameter<bool>("isEmbedded")) {}

--- a/Producers/interface/KElectronProducer.h
+++ b/Producers/interface/KElectronProducer.h
@@ -36,6 +36,26 @@ public:
 
 	doMvaIds_ = (srcIds_ == "pat");
 	doAuxIds_ = (srcIds_ == "standalone");
+
+	const edm::ParameterSet &psBase = this->psBase;
+	std::vector<std::string> names = psBase.getParameterNamesForType<edm::ParameterSet>();
+
+	for (size_t i = 0; i < names.size(); ++i)
+	{
+		const edm::ParameterSet pset = psBase.getParameter<edm::ParameterSet>(names[i]);
+		if(pset.existsAs<edm::InputTag>("allConversions")) consumescollector.consumes<reco::ConversionCollection>(pset.getParameter<edm::InputTag>("allConversions"));
+		if(pset.existsAs<edm::InputTag>("offlineBeamSpot")) consumescollector.consumes<reco::BeamSpot>(pset.getParameter<edm::InputTag>("offlineBeamSpot"));
+		if(pset.existsAs<edm::InputTag>("vertexcollection")) consumescollector.consumes<reco::VertexCollection>(pset.getParameter<edm::InputTag>("vertexcollection"));
+		if(pset.existsAs<edm::InputTag>("rhoIsoInputTag")) consumescollector.consumes<double>(pset.getParameter<edm::InputTag>("rhoIsoInputTag"));
+		if(pset.existsAs<std::vector<edm::InputTag>>("isoValInputTags"))
+		{
+			for(size_t j = 0; j < pset.getParameter<std::vector<edm::InputTag>>("isoValInputTags").size(); ++j) consumescollector.consumes<edm::ValueMap<double>>(pset.getParameter<std::vector<edm::InputTag>>("isoValInputTags").at(j));
+		}
+	}
+    for (size_t j = 0; j < namesOfIds.size(); ++j)
+    {
+        consumescollector.consumes<edm::ValueMap<float> >(edm::InputTag(namesOfIds[j]));
+    }
 }
 
 	static const std::string getLabel() { return "Electrons"; }

--- a/Producers/interface/KElectronProducer.h
+++ b/Producers/interface/KElectronProducer.h
@@ -13,6 +13,7 @@
 #include <DataFormats/PatCandidates/interface/Electron.h>
 #include <RecoEgamma/EgammaTools/interface/ConversionTools.h>
 #include <DataFormats/BeamSpot/interface/BeamSpot.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 #include "EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h"
 #if (CMSSW_MAJOR_VERSION == 5 && CMSSW_MINOR_VERSION == 3 && CMSSW_REVISION >= 15) || (CMSSW_MAJOR_VERSION == 7 && CMSSW_MINOR_VERSION >= 2)
 	#include "EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h"
@@ -22,9 +23,9 @@
 class KElectronProducer : public KBaseMultiLVProducer<edm::View<pat::Electron>, KElectrons>
 {
 public:
-	KElectronProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
+	KElectronProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
 		KBaseMultiLVProducer<edm::View<pat::Electron>,
-		KElectrons>(cfg, _event_tree, _lumi_tree, getLabel()),
+		KElectrons>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)),
 		namesOfIds(cfg.getParameter<std::vector<std::string> >("ids")),
 		srcIds_(cfg.getParameter<std::string>("srcIds")),
 		doPfIsolation_(true),

--- a/Producers/interface/KExtendedTauProducer.h
+++ b/Producers/interface/KExtendedTauProducer.h
@@ -12,12 +12,13 @@
 
 #include "KBasicTauProducer.h"
 #include "KTauProducer.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KExtendedTauProducer : public KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KExtendedTaus>
 {
 public:
-	KExtendedTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KExtendedTaus>(cfg, _event_tree, _lumi_tree, getLabel()) {}
+	KExtendedTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KExtendedTaus>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "ExtendedTaus"; }
 

--- a/Producers/interface/KExtendedTauProducer.h
+++ b/Producers/interface/KExtendedTauProducer.h
@@ -18,7 +18,18 @@ class KExtendedTauProducer : public KBasicTauProducer<reco::PFTau, reco::PFTauDi
 {
 public:
 	KExtendedTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
-		KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KExtendedTaus>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
+		KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KExtendedTaus>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector))
+		{
+			const edm::ParameterSet &psBase = this->psBase;
+			std::vector<std::string> names = psBase.getParameterNamesForType<edm::ParameterSet>();
+
+			for (size_t i = 0; i < names.size(); ++i)
+			{
+				const edm::ParameterSet pset = psBase.getParameter<edm::ParameterSet>(names[i]);
+				if(pset.existsAs<edm::InputTag>("barrelSuperClustersSource")) consumescollector.consumes<reco::SuperClusterCollection>(pset.getParameter<edm::InputTag>("barrelSuperClustersSource"));
+				if(pset.existsAs<edm::InputTag>("endcapSuperClustersSource")) consumescollector.consumes<reco::SuperClusterCollection>(pset.getParameter<edm::InputTag>("endcapSuperClustersSource"));
+			}
+		}
 
 	static const std::string getLabel() { return "ExtendedTaus"; }
 

--- a/Producers/interface/KFilterSummaryProducer.h
+++ b/Producers/interface/KFilterSummaryProducer.h
@@ -8,6 +8,7 @@
 #include "KBaseMatchingProducer.h"
 #include "../../DataFormats/interface/KInfo.h"
 #include <FWCore/Utilities/interface/InputTag.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/FWLite/interface/Event.h"
@@ -17,8 +18,8 @@
 class KFilterSummaryProducer : public KBaseMatchingProducer<KFilterSummary>
 {
 public:
-	KFilterSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KBaseMatchingProducer<KFilterSummary>(cfg, _event_tree, _lumi_tree, getLabel())
+	KFilterSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMatchingProducer<KFilterSummary>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector))
 	{
 		names = new KFilterMetadata;
 		_lumi_tree->Bronch("filterMetadata", "KFilterMetadata", &names);

--- a/Producers/interface/KFilterSummaryProducer.h
+++ b/Producers/interface/KFilterSummaryProducer.h
@@ -23,6 +23,10 @@ public:
 	{
 		names = new KFilterMetadata;
 		_lumi_tree->Bronch("filterMetadata", "KFilterMetadata", &names);
+		consumescollector.consumes<edm::MergeableCounter>(labelEventsTotal);
+		consumescollector.consumes<edm::MergeableCounter>(labelNegEventsTotal);
+		consumescollector.consumes<edm::MergeableCounter>(labelEventsFiltered);
+		consumescollector.consumes<edm::MergeableCounter>(labelNegEventsFiltered);
 	}
 
 	static const std::string getLabel() { return "FilterSummary"; }

--- a/Producers/interface/KGenInfoProducer.h
+++ b/Producers/interface/KGenInfoProducer.h
@@ -13,6 +13,7 @@
 #include <SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h>
 #include <SimDataFormats/GeneratorProducts/interface/HepMCProduct.h>
 #include <SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 #include "KInfoProducer.h"
 
@@ -30,8 +31,8 @@ template<typename Tmeta>
 class KGenInfoProducer : public KInfoProducer<Tmeta>
 {
 public:
-	KGenInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree),
+	KGenInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree, std::forward<edm::ConsumesCollector>(consumescollector)),
 		ignoreExtXSec(cfg.getParameter<bool>("ignoreExtXSec")),
 		forceLumi(cfg.getParameter<int>("forceLumi")),
 		tagSource(cfg.getParameter<edm::InputTag>("genSource")),
@@ -129,8 +130,8 @@ template<typename Tmeta>
 class KHepMCInfoProducer : public KInfoProducer<Tmeta>
 {
 public:
-	KHepMCInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree),
+	KHepMCInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree, std::forward<edm::ConsumesCollector>(consumescollector)),
 		forceXSec(cfg.getParameter<double>("forceXSec")),
 		forceLumi(cfg.getParameter<int>("forceLumi")),
 		tagSource(cfg.getParameter<edm::InputTag>("genSource")) {}

--- a/Producers/interface/KGenInfoProducer.h
+++ b/Producers/interface/KGenInfoProducer.h
@@ -36,7 +36,12 @@ public:
 		ignoreExtXSec(cfg.getParameter<bool>("ignoreExtXSec")),
 		forceLumi(cfg.getParameter<int>("forceLumi")),
 		tagSource(cfg.getParameter<edm::InputTag>("genSource")),
-		puInfoSource(cfg.getParameter<edm::InputTag>("pileUpInfoSource")) {}
+		puInfoSource(cfg.getParameter<edm::InputTag>("pileUpInfoSource"))
+		{
+			consumescollector.consumes<GenRunInfoProduct, edm::InRun>(tagSource);
+			consumescollector.consumes<GenEventInfoProduct>(tagSource);
+			consumescollector.consumes<std::vector<PileupSummaryInfo>>(puInfoSource);
+		}
 
 	static const std::string getLabel() { return "GenInfo"; }
 
@@ -134,7 +139,10 @@ public:
 		KInfoProducer<Tmeta>(cfg, _event_tree, _lumi_tree, std::forward<edm::ConsumesCollector>(consumescollector)),
 		forceXSec(cfg.getParameter<double>("forceXSec")),
 		forceLumi(cfg.getParameter<int>("forceLumi")),
-		tagSource(cfg.getParameter<edm::InputTag>("genSource")) {}
+		tagSource(cfg.getParameter<edm::InputTag>("genSource"))
+		{
+		    consumescollector.consumes<edm::HepMCProduct>(tagSource);
+		}
 
 	static const std::string getLabel() { return "HepMCInfo"; }
 

--- a/Producers/interface/KGenJetProducer.h
+++ b/Producers/interface/KGenJetProducer.h
@@ -6,6 +6,7 @@
 
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "PhysicsTools/JetMCUtils/interface/JetMCTag.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 #include "KBaseMultiLVProducer.h"
 
@@ -13,8 +14,8 @@
 class KGenJetProducer : public KBaseMultiLVProducer<edm::View<reco::GenJet>, KGenJets>
 {
 public:
-	KGenJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KBaseMultiLVProducer<edm::View<reco::GenJet>, KGenJets>(cfg, _event_tree, _lumi_tree, getLabel())
+	KGenJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::GenJet>, KGenJets>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector))
 	{
 	}
 

--- a/Producers/interface/KGenMETProducer.h
+++ b/Producers/interface/KGenMETProducer.h
@@ -15,8 +15,8 @@
 class KGenMETProducer : public KBaseMultiProducer<edm::View<reco::MET>, KMET>
 {
 public:
-	KGenMETProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<edm::View<reco::MET>, KMET>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KGenMETProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<edm::View<reco::MET>, KMET>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "GenMET"; }
 

--- a/Producers/interface/KGenParticleProducer.h
+++ b/Producers/interface/KGenParticleProducer.h
@@ -14,14 +14,15 @@
 
 #include "KBaseMultiProducer.h"
 #include <DataFormats/HepMCCandidate/interface/GenParticle.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 #include <bitset>
 
 template<typename TProduct>
 class KBasicGenParticleProducer : public KBaseMultiLVProducer<edm::View<reco::Candidate>, TProduct>
 {
 public:
-	KBasicGenParticleProducer(const edm::ParameterSet& cfg, TTree* _event_tree, TTree* _run_tree, const std::string& producerName) :
-		KBaseMultiLVProducer<edm::View<reco::Candidate>, TProduct>(cfg, _event_tree, _run_tree, producerName) {}
+	KBasicGenParticleProducer(const edm::ParameterSet& cfg, TTree* _event_tree, TTree* _run_tree, const std::string& producerName, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::Candidate>, TProduct>(cfg, _event_tree, _run_tree, producerName, std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 
 protected:
@@ -114,8 +115,8 @@ private:
 class KGenParticleProducer: public KBasicGenParticleProducer<KGenParticles>
 {
 public:
-	KGenParticleProducer(const edm::ParameterSet& cfg, TTree* _event_tree, TTree* _run_tree) :
-		KBasicGenParticleProducer<KGenParticles>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KGenParticleProducer(const edm::ParameterSet& cfg, TTree* _event_tree, TTree* _run_tree, edm::ConsumesCollector && consumescollector) :
+		KBasicGenParticleProducer<KGenParticles>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel()
 	{

--- a/Producers/interface/KGenPhotonProducer.h
+++ b/Producers/interface/KGenPhotonProducer.h
@@ -9,13 +9,14 @@
 
 #include "KBaseMultiProducer.h"
 #include <DataFormats/HepMCCandidate/interface/GenParticle.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 #include <queue>
 
 class KGenPhotonProducer : public KBaseMultiLVProducer<edm::View<reco::Candidate>, KGenPhotons>
 {
 public:
-	KGenPhotonProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<reco::Candidate>, KGenPhotons>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KGenPhotonProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::Candidate>, KGenPhotons>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "GenPhotons"; }
 

--- a/Producers/interface/KGenTauProducer.h
+++ b/Producers/interface/KGenTauProducer.h
@@ -9,12 +9,13 @@
 
 #include "KGenParticleProducer.h"
 #include <DataFormats/HepMCCandidate/interface/GenParticle.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KGenTauProducer : public KBasicGenParticleProducer<KGenTaus>
 {
 public:
-	KGenTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBasicGenParticleProducer<KGenTaus>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KGenTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBasicGenParticleProducer<KGenTaus>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "GenTaus"; }
 

--- a/Producers/interface/KHCALNoiseSummaryProducer.h
+++ b/Producers/interface/KHCALNoiseSummaryProducer.h
@@ -8,12 +8,13 @@
 #include "../../DataFormats/interface/KBasic.h"
 #include "../../DataFormats/interface/KDebug.h"
 #include <DataFormats/METReco/interface/HcalNoiseSummary.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KHCALNoiseSummaryProducer : public KBaseMultiProducer<HcalNoiseSummary, KHCALNoiseSummary>
 {
 public:
-	KHCALNoiseSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<HcalNoiseSummary, KHCALNoiseSummary>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KHCALNoiseSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<HcalNoiseSummary, KHCALNoiseSummary>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "HCALNoiseSummary"; }
 

--- a/Producers/interface/KHitProducer.h
+++ b/Producers/interface/KHitProducer.h
@@ -7,12 +7,13 @@
 
 #include "KBaseMultiLVProducer.h"
 #include <SimDataFormats/TrackingHit/interface/PSimHit.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KHitProducer : public KBaseMultiVectorProducer<edm::View<PSimHit>, KHits>
 {
 public:
-	KHitProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiVectorProducer<edm::View<PSimHit>, KHits>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KHitProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiVectorProducer<edm::View<PSimHit>, KHits>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "Hits"; }
 

--- a/Producers/interface/KInfoProducer.h
+++ b/Producers/interface/KInfoProducer.h
@@ -22,6 +22,7 @@
 #include <FWCore/MessageLogger/interface/ErrorSummaryEntry.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Utilities/interface/InputTag.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 #include <DataFormats/Common/interface/TriggerResults.h>
 #include <DataFormats/HLTReco/interface/TriggerEvent.h>
@@ -52,8 +53,8 @@ struct KInfo_Product
 class KInfoProducerBase : public KBaseProducerWP
 {
 public:
-	KInfoProducerBase(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KBaseProducerWP(cfg, _event_tree, _lumi_tree, "KInfo") {}
+	KInfoProducerBase(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseProducerWP(cfg, _event_tree, _lumi_tree, "KInfo", std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	virtual ~KInfoProducerBase() {};
 
@@ -73,8 +74,8 @@ template<typename Tmeta>
 class KInfoProducer : public KInfoProducerBase
 {
 public:
-	KInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KInfoProducerBase(cfg, _event_tree, _lumi_tree),
+	KInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KInfoProducerBase(cfg, _event_tree, _lumi_tree, std::forward<edm::ConsumesCollector>(consumescollector)),
 		tauDiscrProcessName(cfg.getUntrackedParameter<std::string>("tauDiscrProcessName", "")),
 		tagL1Results(cfg.getParameter<edm::InputTag>("l1Source")),
 		tagHLTResults(cfg.getParameter<edm::InputTag>("hltSource")),
@@ -257,13 +258,13 @@ public:
 			{
 				const std::string &name = metaLumi->hltNames[i];
 				unsigned int prescale = 0;
-
+/*
 				std::pair<int, int> prescale_L1_HLT = KInfoProducerBase::hltConfig.prescaleValues(event, setup, name);
 				if (prescale_L1_HLT.first < 0 || prescale_L1_HLT.second < 0)
 					prescale = 0;
 				else
 					prescale = prescale_L1_HLT.first * prescale_L1_HLT.second;
-
+*/
 				if (metaLumi->hltPrescales[i] == 0)
 				{
 					if (verbosity > 0 || printHltList)

--- a/Producers/interface/KInfoProducer.h
+++ b/Producers/interface/KInfoProducer.h
@@ -99,6 +99,10 @@ public:
 		{
 			svHLTFailToleranceList.push_back(list[i]);
 		}
+		consumescollector.consumes<L1GlobalTriggerReadoutRecord>(tagL1Results);
+		consumescollector.consumes<edm::TriggerResults>(tagHLTResults);
+		consumescollector.consumes<HcalNoiseSummary>(tagNoiseHCAL);
+		consumescollector.consumes<edm::ErrorSummaryEntry>(tagErrorsAndWarnings);
 	}
 	virtual ~KInfoProducer() {};
 

--- a/Producers/interface/KJetProducer.h
+++ b/Producers/interface/KJetProducer.h
@@ -12,12 +12,13 @@
 #include "../../DataFormats/interface/KJetMET.h"
 #include "../../DataFormats/interface/KDebug.h"
 #include <DataFormats/BTauReco/interface/JetTag.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KJetProducer : public KBaseMultiLVProducer<reco::PFJetCollection, KJets>
 {
 public:
-	KJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<reco::PFJetCollection, KJets>(cfg, _event_tree, _run_tree, getLabel()),
+	KJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<reco::PFJetCollection, KJets>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)),
 		 tagger(cfg.getParameter<std::vector<std::string> >("taggers"))
 {
 		names = new KJetMetadata;

--- a/Producers/interface/KL1MuonProducer.h
+++ b/Producers/interface/KL1MuonProducer.h
@@ -7,12 +7,13 @@
 
 #include "KBaseMultiLVProducer.h"
 #include <DataFormats/L1Trigger/interface/L1MuonParticle.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KL1MuonProducer : public KBaseMultiLVProducer<edm::View<l1extra::L1MuonParticle>, KL1Muons>
 {
 public:
-	KL1MuonProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<l1extra::L1MuonParticle>, KL1MuonProducer_Product>(cfg, _event_tree, _run_tree) {}
+	KL1MuonProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<l1extra::L1MuonParticle>, KL1MuonProducer_Product>(cfg, _event_tree, _run_tree, std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	virtual void fillSingle(const SingleInputType &in, SingleOutputType &out)
 	{

--- a/Producers/interface/KL2MuonProducer.h
+++ b/Producers/interface/KL2MuonProducer.h
@@ -96,7 +96,17 @@ class KMuonTriggerCandidateProducer : public KBaseMultiLVProducer<edm::View<reco
 public:
 	KMuonTriggerCandidateProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
 		KBaseMultiLVProducer<edm::View<reco::RecoChargedCandidate>, KMuonTriggerCandidateProducer_Product>(cfg, _event_tree, _run_tree, std::forward<edm::ConsumesCollector>(consumescollector))
-		{}
+		{
+			const edm::ParameterSet &psBase = this->psBase;
+			std::vector<std::string> names = psBase.getParameterNamesForType<edm::ParameterSet>();
+
+			for (size_t i = 0; i < names.size(); ++i)
+			{
+				const edm::ParameterSet pset = psBase.getParameter<edm::ParameterSet>(names[i]);
+				if(pset.existsAs<edm::InputTag>("srcIsolation")) consumescollector.consumes<edm::ValueMap<reco::IsoDeposit>>(pset.getParameter<edm::InputTag>("srcIsolation"));
+				if(pset.existsAs<edm::InputTag>("srcIsolation")) consumescollector.consumes<edm::ValueMap<bool>>(pset.getParameter<edm::InputTag>("srcIsolation"));
+			}
+		}
 
 	virtual void fillProduct(const InputType &in, OutputType &out,
 		const std::string &name, const edm::InputTag *tag, const edm::ParameterSet &pset)

--- a/Producers/interface/KL2MuonProducer.h
+++ b/Producers/interface/KL2MuonProducer.h
@@ -14,6 +14,7 @@
 #include <DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h>
 #include <DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h>
 #include <DataFormats/RecoCandidate/interface/RecoChargedCandidate.h> 
+#include <FWCore/Framework/interface/EDProducer.h>
 
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
@@ -45,8 +46,8 @@ struct KMuonTriggerCandidateProducer_Product
 class KL2MuonTrajectorySeedProducer : public KBaseMultiProducer<std::vector<L2MuonTrajectorySeed>, KL2MuonTrajectorySeedProducer_Product>
 {
 public:
-	KL2MuonTrajectorySeedProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<std::vector<L2MuonTrajectorySeed>, KL2MuonTrajectorySeedProducer_Product>(cfg, _event_tree, _run_tree) {}
+	KL2MuonTrajectorySeedProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<std::vector<L2MuonTrajectorySeed>, KL2MuonTrajectorySeedProducer_Product>(cfg, _event_tree, _run_tree, std::forward<edm::ConsumesCollector>(consumescollector)) {}
 	virtual ~KL2MuonTrajectorySeedProducer() {};
 
 protected:
@@ -68,8 +69,8 @@ protected:
 class KL3MuonTrajectorySeedProducer : public KBaseMultiProducer<std::vector<L3MuonTrajectorySeed>, KL3MuonTrajectorySeedProducer_Product>
 {
 public:
-	KL3MuonTrajectorySeedProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<std::vector<L3MuonTrajectorySeed>, KL3MuonTrajectorySeedProducer_Product>(cfg, _event_tree, _run_tree) {}
+	KL3MuonTrajectorySeedProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<std::vector<L3MuonTrajectorySeed>, KL3MuonTrajectorySeedProducer_Product>(cfg, _event_tree, _run_tree, std::forward<edm::ConsumesCollector>(consumescollector)) {}
 	virtual ~KL3MuonTrajectorySeedProducer() {};
 
 protected:
@@ -93,8 +94,8 @@ protected:
 class KMuonTriggerCandidateProducer : public KBaseMultiLVProducer<edm::View<reco::RecoChargedCandidate>, KMuonTriggerCandidateProducer_Product>
 {
 public:
-	KMuonTriggerCandidateProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<reco::RecoChargedCandidate>, KMuonTriggerCandidateProducer_Product>(cfg, _event_tree, _run_tree)
+	KMuonTriggerCandidateProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::RecoChargedCandidate>, KMuonTriggerCandidateProducer_Product>(cfg, _event_tree, _run_tree, std::forward<edm::ConsumesCollector>(consumescollector))
 		{}
 
 	virtual void fillProduct(const InputType &in, OutputType &out,

--- a/Producers/interface/KLHEProducer.h
+++ b/Producers/interface/KLHEProducer.h
@@ -8,12 +8,13 @@
 #include <SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h>
 #include "KBaseMultiProducer.h"
 #include "../../DataFormats/interface/KBasic.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KLHEProducer : public KBaseMultiProducer<LHEEventProduct, KGenParticles>
 {
 public:
-	KLHEProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree):
-		KBaseMultiProducer<LHEEventProduct, KGenParticles>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KLHEProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector):
+		KBaseMultiProducer<LHEEventProduct, KGenParticles>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 	virtual ~KLHEProducer() {};
 
 	static const std::string getLabel() { return "LHE"; }

--- a/Producers/interface/KLeptonPairProducer.h
+++ b/Producers/interface/KLeptonPairProducer.h
@@ -25,6 +25,8 @@ public:
 		electronsTag(cfg.getParameter<edm::InputTag>("electrons")),
 		muonsTag(cfg.getParameter<edm::InputTag>("muons"))
 	{
+		consumescollector.consumes<edm::View<pat::Electron>>(electronsTag);
+		consumescollector.consumes<edm::View<reco::Muon>>(muonsTag);
 	}
 
 	static const std::string getLabel() { return "LeptonPair"; }

--- a/Producers/interface/KLeptonPairProducer.h
+++ b/Producers/interface/KLeptonPairProducer.h
@@ -10,6 +10,7 @@
 #include <TrackingTools/TransientTrack/interface/TransientTrackBuilder.h>
 #include <TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h>
 #include <RecoVertex/KinematicFitPrimitives/interface/KinematicParticleFactoryFromTransientTrack.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 #include "KBaseMultiProducer.h"
 #include "Kappa/DataFormats/interface/Hash.h"
@@ -19,8 +20,8 @@ class KLeptonPairProducer : public KBaseMultiProducer<edm::View<reco::Track>, KL
 {
 
 public:
-	KLeptonPairProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<edm::View<reco::Track>, KLeptonPairs>(cfg, _event_tree, _run_tree, getLabel()),
+	KLeptonPairProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<edm::View<reco::Track>, KLeptonPairs>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)),
 		electronsTag(cfg.getParameter<edm::InputTag>("electrons")),
 		muonsTag(cfg.getParameter<edm::InputTag>("muons"))
 	{

--- a/Producers/interface/KLorentzProducer.h
+++ b/Producers/interface/KLorentzProducer.h
@@ -9,12 +9,13 @@
 #include <DataFormats/JetReco/interface/CaloJet.h>
 #include <DataFormats/METReco/interface/HcalNoiseRBX.h>
 #include <DataFormats/TrackReco/interface/Track.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KLorentzProducer : public KBaseMultiLVProducer<edm::View<reco::Candidate>, KLVs>
 {
 public:
-	KLorentzProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<reco::Candidate>, KLVs>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KLorentzProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::Candidate>, KLVs>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "LV"; }
 

--- a/Producers/interface/KMETProducer.h
+++ b/Producers/interface/KMETProducer.h
@@ -11,12 +11,13 @@
 #include "../../DataFormats/interface/KBasic.h"
 #include "../../DataFormats/interface/KDebug.h"
 #include <DataFormats/METReco/interface/PFMET.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KMETProducer : public KBaseMultiProducer<edm::View<reco::PFMET>, KMET>
 {
 public:
-	KMETProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<edm::View<reco::PFMET>, KMET>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KMETProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<edm::View<reco::PFMET>, KMET>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "MET"; }
 

--- a/Producers/interface/KMuonProducer.h
+++ b/Producers/interface/KMuonProducer.h
@@ -30,12 +30,13 @@
 #include <TrackingTools/Records/interface/TrackingComponentsRecord.h>
 #include <TrackingTools/Records/interface/TransientTrackRecord.h>
 #include <TrackingTools/TransientTrack/interface/TransientTrackBuilder.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KMuonProducer : public KBaseMultiLVProducer<edm::View<reco::Muon>, KMuons>
 {
 public:
-	KMuonProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KBaseMultiLVProducer<edm::View<reco::Muon>, KMuons>(cfg, _event_tree, _lumi_tree, getLabel()),
+	KMuonProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::Muon>, KMuons>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)),
 		tagHLTrigger(cfg.getParameter<edm::InputTag>("hlTrigger")),
 		hltMaxdR(cfg.getParameter<double>("hltMaxdR")),
 		hltMaxdPt_Pt(cfg.getParameter<double>("hltMaxdPt_Pt")),

--- a/Producers/interface/KMuonProducer.h
+++ b/Producers/interface/KMuonProducer.h
@@ -55,6 +55,20 @@ public:
 		muonMetadata = new KMuonMetadata();
 		_lumi_tree->Bronch("muonMetadata", "KMuonMetadata", &muonMetadata);
 
+        consumescollector.consumes<trigger::TriggerEvent>(tagHLTrigger);
+        const edm::ParameterSet &psBase = this->psBase;
+        std::vector<std::string> names = psBase.getParameterNamesForType<edm::ParameterSet>();
+
+        for (size_t i = 0; i < names.size(); ++i)
+        {
+            const edm::ParameterSet pset = psBase.getParameter<edm::ParameterSet>(names[i]);
+            if(pset.existsAs<edm::InputTag>("srcMuonIsolationPF")) consumescollector.consumes<edm::ValueMap<reco::IsoDeposit>>(pset.getParameter<edm::InputTag>("srcMuonIsolationPF"));
+            if(pset.existsAs<edm::InputTag>("vertexcollection")) consumescollector.consumes<edm::View<reco::Vertex>>(pset.getParameter<edm::InputTag>("vertexcollection"));
+            if(pset.existsAs<std::vector<edm::InputTag>>("isoValInputTags"))
+            {
+                for(size_t j = 0; j < pset.getParameter<std::vector<edm::InputTag>>("isoValInputTags").size(); ++j) consumescollector.consumes<edm::ValueMap<double>>(pset.getParameter<std::vector<edm::InputTag>>("isoValInputTags").at(j));
+            }
+        }
 	}
 
 	static const std::string getLabel() { return "Muons"; }

--- a/Producers/interface/KPFCandidateProducer.h
+++ b/Producers/interface/KPFCandidateProducer.h
@@ -9,12 +9,13 @@
 
 #include "KBaseMultiLVProducer.h"
 #include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KPFCandidateProducer : public KBaseMultiLVProducer<edm::View<reco::PFCandidate>, KPFCandidates>
 {
 public:
-	KPFCandidateProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<reco::PFCandidate>, KPFCandidates>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KPFCandidateProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::PFCandidate>, KPFCandidates>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "PFCandidates"; }
 

--- a/Producers/interface/KPackedPFCandidateProducer.h
+++ b/Producers/interface/KPackedPFCandidateProducer.h
@@ -9,12 +9,13 @@
 
 #include "KBaseMultiLVProducer.h"
 #include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KPackedPFCandidateProducer : public KBaseMultiLVProducer<edm::View<pat::PackedCandidate>, KPFCandidates>
 {
 public:
-	KPackedPFCandidateProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<pat::PackedCandidate>, KPFCandidates>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KPackedPFCandidateProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<pat::PackedCandidate>, KPFCandidates>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "packedPFCandidates"; }
 

--- a/Producers/interface/KPatJetProducer.h
+++ b/Producers/interface/KPatJetProducer.h
@@ -12,12 +12,13 @@
 #include "KBaseMultiLVProducer.h"
 #include "KGenJetProducer.h"
 #include <DataFormats/PatCandidates/interface/Jet.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KPatJetProducer : public KBaseMultiLVProducer<edm::View<pat::Jet>, KJets >
 {
 public:
-	KPatJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<pat::Jet>, KJets>(cfg, _event_tree, _run_tree, getLabel())
+	KPatJetProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<pat::Jet>, KJets>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector))
 	{
 		genJet = new KGenJet;
 		_event_tree->Bronch("genJet", "KGenJet", &genJet);

--- a/Producers/interface/KPatMETProducer.h
+++ b/Producers/interface/KPatMETProducer.h
@@ -13,12 +13,13 @@
 #include "../../DataFormats/interface/KDebug.h"
 #include <DataFormats/METReco/interface/PFMET.h>
 #include <DataFormats/PatCandidates/interface/MET.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KPatMETProducer : public KBaseMultiProducer<edm::View<pat::MET>, KMET>
 {
 public:
-	KPatMETProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<edm::View<pat::MET>, KMET>(cfg, _event_tree, _run_tree, getLabel()) {
+	KPatMETProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<edm::View<pat::MET>, KMET>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {
 		genMet = new KMET;
 		_event_tree->Bronch("genmetTrue", "KMET", &genMet);
 	}

--- a/Producers/interface/KPatMETsProducer.h
+++ b/Producers/interface/KPatMETsProducer.h
@@ -13,12 +13,13 @@
 #include "../../DataFormats/interface/KDebug.h"
 #include <DataFormats/PatCandidates/interface/MET.h>
 #include "Kappa/DataFormats/interface/Hash.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KPatMETsProducer : public KBaseMultiLVProducer<edm::View<pat::MET>, KMETs>
 {
 public:
-	KPatMETsProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<pat::MET>, KMETs>(cfg, _event_tree, _run_tree, getLabel()) {
+	KPatMETsProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<pat::MET>, KMETs>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {
 	}
 
 	static const std::string getLabel() { return "PatMETs"; }

--- a/Producers/interface/KPatTauProducer.h
+++ b/Producers/interface/KPatTauProducer.h
@@ -6,6 +6,7 @@
 #include "KBaseMultiLVProducer.h"
 
 #include <DataFormats/PatCandidates/interface/Tau.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 
 class KPatTauProducer : public KBaseMultiLVProducer<edm::View<pat::Tau>, KTaus>
@@ -94,8 +95,8 @@ protected:
 	}
 
 public:
-	KPatTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KBaseMultiLVProducer<edm::View<pat::Tau>, KTaus>(cfg, _event_tree, _lumi_tree, getLabel()),
+	KPatTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<pat::Tau>, KTaus>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)),
 		_lumi_tree_pointer(_lumi_tree)
 	{
 		const edm::ParameterSet &psBase = this->psBase;

--- a/Producers/interface/KPileupDensityProducer.h
+++ b/Producers/interface/KPileupDensityProducer.h
@@ -9,12 +9,13 @@
 #include "KBaseMultiProducer.h"
 #include "../../DataFormats/interface/KJetMET.h"
 #include "../../DataFormats/interface/KDebug.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KPileupDensityProducer : public KBaseMultiProducer<double, KPileupDensity>
 {
 public:
-	KPileupDensityProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<double, KPileupDensity>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KPileupDensityProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<double, KPileupDensity>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "PileupDensity"; }
 

--- a/Producers/interface/KTauProducer.h
+++ b/Producers/interface/KTauProducer.h
@@ -18,14 +18,15 @@
 
 #include <DataFormats/TauReco/interface/PFTau.h>
 #include <DataFormats/TauReco/interface/PFTauDiscriminator.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 #include "KBasicTauProducer.h"
 
 class KTauProducer : public KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KTaus>
 {
 public:
-	KTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree) :
-		KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KTaus>(cfg, _event_tree, _lumi_tree, getLabel()) {}
+	KTauProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector) :
+		KBasicTauProducer<reco::PFTau, reco::PFTauDiscriminator, KTaus>(cfg, _event_tree, _lumi_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "Taus"; }
 

--- a/Producers/interface/KTaupairVerticesMapProducer.h
+++ b/Producers/interface/KTaupairVerticesMapProducer.h
@@ -15,12 +15,13 @@
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KTaupairVerticesMapProducer : public KBaseMultiVectorProducer<edm::View<reco::Vertex>, KTaupairVerticesMaps>
 {
 public:
-	KTaupairVerticesMapProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiVectorProducer<edm::View<reco::Vertex>, KTaupairVerticesMaps>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KTaupairVerticesMapProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiVectorProducer<edm::View<reco::Vertex>, KTaupairVerticesMaps>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "TaupairVerticesMap"; }
 

--- a/Producers/interface/KTowerProducer.h
+++ b/Producers/interface/KTowerProducer.h
@@ -18,7 +18,10 @@ class KTowerProducer : public KBaseMultiLVProducer<CaloTowerCollection, KLVs>
 public:
 	KTowerProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
 		KBaseMultiLVProducer<CaloTowerCollection, KLVs>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)),
-		srcPVs(cfg.getParameter<edm::InputTag>("srcPVs")) {}
+		srcPVs(cfg.getParameter<edm::InputTag>("srcPVs"))
+		{
+			consumescollector.consumes<reco::VertexCollection>(srcPVs);
+		}
 
 	static const std::string getLabel() { return "Tower"; }
 

--- a/Producers/interface/KTowerProducer.h
+++ b/Producers/interface/KTowerProducer.h
@@ -11,12 +11,13 @@
 #include <DataFormats/JetReco/interface/CaloJet.h>
 #include <DataFormats/VertexReco/interface/Vertex.h>
 #include <DataFormats/VertexReco/interface/VertexFwd.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KTowerProducer : public KBaseMultiLVProducer<CaloTowerCollection, KLVs>
 {
 public:
-	KTowerProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<CaloTowerCollection, KLVs>(cfg, _event_tree, _run_tree, getLabel()),
+	KTowerProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<CaloTowerCollection, KLVs>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)),
 		srcPVs(cfg.getParameter<edm::InputTag>("srcPVs")) {}
 
 	static const std::string getLabel() { return "Tower"; }

--- a/Producers/interface/KTrackProducer.h
+++ b/Producers/interface/KTrackProducer.h
@@ -12,12 +12,13 @@
 #include <DataFormats/TrackReco/interface/Track.h>
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KTrackProducer : public KBaseMultiLVProducer<edm::View<reco::Track>, KTracks>
 {
 public:
-	KTrackProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiLVProducer<edm::View<reco::Track>, KTracks>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KTrackProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiLVProducer<edm::View<reco::Track>, KTracks>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "Tracks"; }
 

--- a/Producers/interface/KTrackSummaryProducer.h
+++ b/Producers/interface/KTrackSummaryProducer.h
@@ -7,12 +7,13 @@
 
 #include "KBaseMultiProducer.h"
 #include <DataFormats/TrackReco/interface/Track.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KTrackSummaryProducer : public KBaseMultiProducer<edm::View<reco::Track>, KTrackSummary>
 {
 public:
-	KTrackSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<edm::View<reco::Track>, KTrackSummary>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KTrackSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<edm::View<reco::Track>, KTrackSummary>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "TrackSummary"; }
 

--- a/Producers/interface/KTreeInfoProducer.h
+++ b/Producers/interface/KTreeInfoProducer.h
@@ -6,11 +6,13 @@
 #ifndef KAPPA_TREE_METADATAPRODUCER_H
 #define KAPPA_TREE_METADATAPRODUCER_H
 
+#include <FWCore/Framework/interface/EDProducer.h>
+
 
 class KTreeInfoProducer: public KBaseProducer
 {
 public:
-	KTreeInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree)
+	KTreeInfoProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, edm::ConsumesCollector && consumescollector)
 	{
 	
 		TList* keys = new TList();

--- a/Producers/interface/KTriggerObjectProducer.h
+++ b/Producers/interface/KTriggerObjectProducer.h
@@ -13,6 +13,7 @@
 #include "KBaseMultiProducer.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Utilities/interface/InputTag.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 #include <DataFormats/MuonReco/interface/Muon.h>
 #include <algorithm>
 
@@ -29,8 +30,8 @@ struct KTrgObjSorter
 class KTriggerObjectProducer : public KBaseMultiProducer<trigger::TriggerEvent, KTriggerObjects>
 {
 public:
-	KTriggerObjectProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<trigger::TriggerEvent, KTriggerObjects>(cfg, _event_tree, _run_tree, getLabel(), true)
+	KTriggerObjectProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<trigger::TriggerEvent, KTriggerObjects>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector), true)
 	{
 		toMetadata = new KTriggerObjectMetadata;
 		_run_tree->Bronch("triggerObjectMetadata", "KTriggerObjectMetadata", &toMetadata);

--- a/Producers/interface/KTriggerObjectStandaloneProducer.h
+++ b/Producers/interface/KTriggerObjectStandaloneProducer.h
@@ -29,8 +29,8 @@
 class KTriggerObjectStandaloneProducer : public KBaseMultiProducer<pat::TriggerObjectStandAloneCollection, KTriggerObjects>
 {
 public:
-	KTriggerObjectStandaloneProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<pat::TriggerObjectStandAloneCollection, KTriggerObjects>(cfg, _event_tree, _run_tree, getLabel(), true)
+	KTriggerObjectStandaloneProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<pat::TriggerObjectStandAloneCollection, KTriggerObjects>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector), true)
 	{
 		triggerBits_ = cfg.getParameter<edm::InputTag>("bits");
 		triggerObjects_ = cfg.getParameter<edm::InputTag>("objects");

--- a/Producers/interface/KTriggerObjectStandaloneProducer.h
+++ b/Producers/interface/KTriggerObjectStandaloneProducer.h
@@ -39,6 +39,9 @@ public:
 		toMetadata = new KTriggerObjectMetadata;
 		_run_tree->Bronch("triggerObjectMetadata", "KTriggerObjectMetadata", &toMetadata);
 
+		consumescollector.consumes<edm::TriggerResults>(triggerBits_);
+		consumescollector.consumes<pat::TriggerObjectStandAloneCollection>(triggerObjects_);
+		consumescollector.consumes<pat::PackedTriggerPrescales>(triggerPrescales_);
 	}
 
 	static const std::string getLabel() { return "TriggerObjectStandalone"; }

--- a/Producers/interface/KVertexProducer.h
+++ b/Producers/interface/KVertexProducer.h
@@ -11,12 +11,13 @@
 #include "../../DataFormats/interface/KBasic.h"
 #include "../../DataFormats/interface/KDebug.h"
 #include <DataFormats/VertexReco/interface/Vertex.h>
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KVertexProducer : public KBaseMultiVectorProducer<edm::View<reco::Vertex>, std::vector<KVertex> >
 {
 public:
-	KVertexProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiVectorProducer<edm::View<reco::Vertex>, std::vector<KVertex> >(cfg, _event_tree, _run_tree, getLabel()) {}
+	KVertexProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiVectorProducer<edm::View<reco::Vertex>, std::vector<KVertex> >(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "Vertex"; }
 

--- a/Producers/interface/KVertexSummaryProducer.h
+++ b/Producers/interface/KVertexSummaryProducer.h
@@ -6,12 +6,13 @@
 #define KAPPA_VERTEXSUMMARYPRODUCER_H
 
 #include "KVertexProducer.h"
+#include <FWCore/Framework/interface/EDProducer.h>
 
 class KVertexSummaryProducer : public KBaseMultiProducer<edm::View<reco::Vertex>, KVertexSummary>
 {
 public:
-	KVertexSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree) :
-		KBaseMultiProducer<edm::View<reco::Vertex>, KVertexSummary>(cfg, _event_tree, _run_tree, getLabel()) {}
+	KVertexSummaryProducer(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_run_tree, edm::ConsumesCollector && consumescollector) :
+		KBaseMultiProducer<edm::View<reco::Vertex>, KVertexSummary>(cfg, _event_tree, _run_tree, getLabel(), std::forward<edm::ConsumesCollector>(consumescollector)) {}
 
 	static const std::string getLabel() { return "VertexSummary"; }
 

--- a/Producers/src/KBaseProducer.cc
+++ b/Producers/src/KBaseProducer.cc
@@ -137,8 +137,7 @@ bool KBaseProducer::fail(const std::ostream &s)
 	return false;
 }
 
-KBaseProducerWP::KBaseProducerWP(const edm::ParameterSet &cfg,
-	TTree *_event_tree, TTree *_lumi_tree, const std::string &producerName) : psBase(cfg)
+KBaseProducerWP::KBaseProducerWP(const edm::ParameterSet &cfg, TTree *_event_tree, TTree *_lumi_tree, const std::string &producerName, edm::ConsumesCollector && consumescollector) : psBase(cfg)
 {
 	provenance = new KProvenance();
 	_lumi_tree->Bronch(("provenance_" + producerName).c_str(), "KProvenance", &provenance);

--- a/Producers/src/KTuple.cc
+++ b/Producers/src/KTuple.cc
@@ -110,7 +110,7 @@ protected:
 			if (sName == "")
 				sName = sActive;
 			std::cout << "Init producer " << sActive << " using config from " << sName << std::endl;
-			producers.push_back(new Tprod(psConfig.getParameter<edm::ParameterSet>(sName), event_tree, lumi_tree));
+			producers.push_back(new Tprod(psConfig.getParameter<edm::ParameterSet>(sName), event_tree, lumi_tree, consumesCollector()));
 			producers.back()->runRuntime = 0;
 			producers.back()->lumiRuntime = 0;
 			producers.back()->firstRuntime = 0;

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -79,7 +79,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.p *= process.nNegEventsTotal
 	## ------------------------------------------------------------------------
 	# General configuration
-	if (cmssw_version_number.startswith("7_4") and split_cmssw_version[2] >= 14):
+	if ((cmssw_version_number.startswith("7_4") and split_cmssw_version[2] >= 14) or (cmssw_version_number.startswith("7_6"))):
 		process.kappaTuple.Info.pileUpInfoSource = cms.InputTag("slimmedAddPileupInfo")
 
 	process.kappaTuple.active += cms.vstring('VertexSummary')            # save VertexSummary,
@@ -90,13 +90,16 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 		if (cmssw_version_number.startswith("7_4")):
 			process.kappaTuple.VertexSummary.whitelist = cms.vstring('offlineSlimmedPrimaryVertices')  # save VertexSummary,
 			process.kappaTuple.VertexSummary.rename = cms.vstring('offlineSlimmedPrimaryVertices => goodOfflinePrimaryVerticesSummary')
+		elif (cmssw_version_number.startswith("7_6")):
+			process.kappaTuple.VertexSummary.goodOfflinePrimaryVerticesSummary = cms.PSet(src=cms.InputTag("offlineSlimmedPrimaryVertices"))
 		else:
 			process.kappaTuple.VertexSummary.whitelist = cms.vstring('goodOfflinePrimaryVertices')  # save VertexSummary,
 
 		process.kappaTuple.active += cms.vstring('TriggerObjectStandalone')
 
 	process.kappaTuple.active += cms.vstring('BeamSpot')                 # save Beamspot,
-
+	if (cmssw_version_number.startswith("7_6")):
+		process.kappaTuple.BeamSpot.offlineBeamSpot = cms.PSet(src = cms.InputTag("offlineBeamSpot"))
 	if not miniaod:
 		process.kappaTuple.active += cms.vstring('TriggerObjects')
 
@@ -153,6 +156,8 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	if(miniaod):
 		process.kappaTuple.active += cms.vstring('packedPFCandidates') # save PFCandidates. Not sure for what, because might not be usefull for isolation
+		if (cmssw_version_number.startswith("7_6")):
+			process.kappaTuple.packedPFCandidates.packedPFCandidates = cms.PSet(src = cms.InputTag("packedPFCandidates"))
 
 	## ------------------------------------------------------------------------
 	# Configure Muons
@@ -181,7 +186,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 		from Kappa.Skimming.KElectrons_miniAOD_cff import setupElectrons
 		process.kappaTuple.Electrons.srcIds = cms.string("standalone");
 
-		if (cmssw_version_number.startswith("7_4")):
+		if (cmssw_version_number.startswith("7_4") or cmssw_version_number.startswith("7_6")):
 			process.kappaTuple.Electrons.ids = cms.vstring("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 						"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
 						"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
@@ -259,6 +264,10 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	if miniaod:
 		process.kappaTuple.active += cms.vstring('PatJets')
+		if (cmssw_version_number.startswith("7_6")):
+			process.kappaTuple.PatJets.ak4PF = cms.PSet(src=cms.InputTag("slimmedJets"))
+	if (cmssw_version_number.startswith("7_6")):
+		process.kappaTuple.PileupDensity.pileupDensity = cms.PSet(src=cms.InputTag("fixedGridRhoFastjetAll"))
 	process.kappaTuple.PileupDensity.whitelist = cms.vstring("fixedGridRhoFastjetAll")
 	process.kappaTuple.PileupDensity.rename = cms.vstring("fixedGridRhoFastjetAll => pileupDensity")
 
@@ -317,6 +326,8 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 			)
 		process.kappaTuple.GenJets.whitelist = cms.vstring("tauGenJets")
 		process.kappaTuple.active += cms.vstring('GenJets')
+		if (cmssw_version_number.startswith("7_6")):
+			process.kappaTuple.GenJets.tauGenJets = cms.PSet(src=cms.InputTag("tauGenJets"))
 
 	## ------------------------------------------------------------------------
 	## Further information saved to Kappa output 

--- a/Skimming/python/KElectrons_miniAOD_cff.py
+++ b/Skimming/python/KElectrons_miniAOD_cff.py
@@ -7,7 +7,7 @@ cmssw_version_number = tools.get_cmssw_version_number()
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
 
-if (cmssw_version_number.startswith("7_4")):
+if (cmssw_version_number.startswith("7_4") or cmssw_version_number.startswith("7_6")):
 	# https://github.com/ikrav/EgammaWork/blob/v1/ElectronNtupler/test/runElectrons_VID_MVA_PHYS14_demo.py
 	from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDElectronIdProducer, DataFormat
 	from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import *
@@ -21,7 +21,7 @@ else:
 egmGsfElectronIDs.physicsObjectSrc = cms.InputTag('slimmedElectrons')
 
 def setupElectrons(process):
-	if (cmssw_version_number.startswith("7_4")):
+	if (cmssw_version_number.startswith("7_4") or cmssw_version_number.startswith("7_6")):
 		switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 		my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
 				 'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff']

--- a/Skimming/python/KSkimming_template_cfg.py
+++ b/Skimming/python/KSkimming_template_cfg.py
@@ -33,7 +33,7 @@ import Kappa.Skimming.tools as tools
 cmssw_version_number = tools.get_cmssw_version_number()
 split_cmssw_version = cmssw_version_number.split("_") 
 
-if (cmssw_version_number.startswith("7_4")):
+if (cmssw_version_number.startswith("7_4") or cmssw_version_number.startswith("7_6")):
 	# see https://twiki.cern.ch/twiki/bin/view/Sandbox/MyRootMakerFrom72XTo74X#DDVectorGetter_vectors_are_empty
 	print "Use GeometryRecoDB and condDBv2"
 	process.load("Configuration.Geometry.GeometryRecoDB_cff")

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.py
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-# Copyright (c) 2014 - All Rights Reserved
+#-#   Raphael Friese <Raphael.Friese@cern.ch>
+#-#   Stefan Wayand <stefan.wayand@gmail.com>
+#-#   Thomas Mueller <tmuller@cern.ch>
+
+# checkout script for cmssw53x for skimming
+# todo: implement logger
+# todo: make cmsenv/scramv work
+
+import os
+import sys
+from optparse import OptionParser
+
+#################################################################################################################
+
+
+def execCommands(commands):
+	for command in commands:
+		print ""
+		print "command: " + command
+		exitCode = 1
+		nTrials = 0
+		while exitCode != 0:
+			if nTrials > 1:
+				print "Last command could NOT be executed successfully! Stop program!"
+				sys.exit(1)
+
+				#logger.info("{CHECKOUT_COMMAND} (trial {N_TRIAL}):").formal(CHECKOUT_COMMAND = command, N_TRIAL = (nTrials+1))
+
+			if command.startswith("cd"):
+				os.chdir(os.path.expandvars(command.replace("cd ", "")))
+				exitCode = int((os.path.expandvars(command.replace("cd ", "").strip("/")) != os.getcwd().strip("/")))
+			else:
+				exitCode = os.system(command)
+
+			nTrials += 1
+
+	return
+
+#################################################################################################################
+
+
+def getSysInformation():
+	sysInformation = {
+	"github_username": os.popen("git config user.name").readline().replace("\n", ""),
+	"email": os.popen("git config user.email").readline().replace("\n", ""),
+	"editor": os.popen("git config core.editor").readline().replace("\n", ""),
+	"pwd": os.getcwd()
+	}
+	return sysInformation
+
+
+#################################################################################################################
+
+
+def checkoutPackages(args):
+	commands = [
+		"cd " + os.path.expandvars("$CMSSW_BASE/src/"),
+		# do the git cms-addpkg before starting with checking out cvs repositories
+
+		#MVA & No-PU MET Recipe
+		#https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#Instructions_for_7_4_X
+		#everything needed is already in the 7_4_6 release -> only use 7_4_7 due to bugfix!
+		#Jan's multi-MET Producer
+		"git cms-addpkg RecoMET/METPUSubtraction",
+		"cd " + os.path.expandvars("$CMSSW_BASE/src/RecoMET/METPUSubtraction/plugins"),
+		"wget https://raw.githubusercontent.com/CERN-PH-CMG/cmg-cmssw/CMGTools-from-CMSSW_7_4_3/RecoMET/METPUSubtraction/plugins/PFMETProducerMVATauTau.cc",
+		"wget https://raw.githubusercontent.com/CERN-PH-CMG/cmg-cmssw/CMGTools-from-CMSSW_7_4_3/RecoMET/METPUSubtraction/plugins/PFMETProducerMVATauTau.h",
+		#"git remote add cmgtools https://github.com/CERN-PH-CMG/cmg-cmssw.git",
+		#"git pull cmgtools",
+		#"git checkout CMGTools-from-CMSSW_7_4_7",
+		"cd " + os.path.expandvars("$CMSSW_BASE/src/RecoMET/METPUSubtraction/"),
+		"git clone https://github.com/rfriese/RecoMET-METPUSubtraction data -b 74X-13TeV-Summer15-July2015 --depth 1",
+		"rm -rf $CMSSW_BASE/src/RecoMET/METPUSubtraction/data/.git/",
+		"cd " + os.path.expandvars("$CMSSW_BASE/src/"),
+
+		"git cms-addpkg PhysicsTools/PatUtils",
+		#"sed '/pat::MET outMET/a \ \ \  outMET\.setSignificanceMatrix\(srcMET\.getSignificanceMatrix\(\)\)\;' PhysicsTools/PatUtils/plugins/CorrectedPATMETProducer.cc -i",
+
+		#PF MET with NoHF MET
+		#https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription
+		"git cms-merge-topic -u cms-met:mvaMetBugfix76X",
+
+		#Electron cutBased Id and MVA Id
+		#https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_for_747
+		#https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#Recipes_for_747_Spring15_MVA_tra
+		#"git cms-merge-topic ikrav:egm_id_747_v2",
+
+		#Check out Kappa
+		"git clone https://github.com/KappaAnalysis/Kappa.git",
+		#"scram b -j 4"
+	]
+	execCommands(commands)
+	return
+
+
+#################################################################################################################
+
+
+def main():
+	parser = OptionParser()
+	sysInformation = getSysInformation()
+
+	parser.add_option("--github_username", help="your name as in github. Default: " + sysInformation["github_username"], default=sysInformation["github_username"], nargs='?')
+	parser.add_option("--mail", help="your email. Default: " + sysInformation["email"], default=sysInformation["email"], nargs='?')
+	parser.add_option("--editor", help="your favorite editor (ex. emacs). Default: " + sysInformation["editor"], default=sysInformation["editor"], nargs='?')
+	parser.add_option("--cmssw_version", help="the CMSSW Version to checko out. Default: CMSSW_7_2_2", default="CMSSW_7_2_2", nargs='?')
+
+	#args = parser.parse_args()
+	(options, args) = parser.parse_args()
+	checkoutPackages(args)
+
+
+#################################################################################################################
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
Dear all,

I had a first look into making Kappa compatible with the requirements from CMSSW_7_6_X. So far I took care of implementing the usage of the consumes functionality which is required with CMSSW_7_6_X.
For this work it was necessary to have the inputTag we use already available in the constructor of the KBaseMultiProducer. Hence some heavy modifications to the KBaseMatchingProducer were required, disabling the filling of the targetSetupMap onFirst event and instead doing so on the constructor level. For now this also induced removing the functionality for the processing of white- and blacklists in Kappa.

Please be reminded to points not addressed by this suggestion:
- with this state we will currently not be backward compatible with CMSSW_5_3_X. For this we will need to add a dummy edm::ConsumesCollector (Andrew already has given some suggestions on how to do this).
- with the current implementation we do not have the possibility anymore to use white- and blacklists in Kappa. We can certainly implement a backward-compatilbity allowing us to use them for CMSSW version < 7.6, however for CMSSW 7.6 I currently do not see any nice option for implementing this.

Please feel free to comment.

Cheers,
Rene
