### PR TITLE
Adding new quantities (jetFlavour, HT)

### DIFF
--- a/DataFormats/interface/KInfo.h
+++ b/DataFormats/interface/KInfo.h
@@ -113,7 +113,6 @@ struct KGenEventInfo : public KEventInfo
 	double weight;                      //< Monte-Carlo weight of the event
 	double binValue;                    //< ?
 	double alphaQCD;                    //< value of alpha_S for this event
-	double lheHt;                       //< p-T sum of the outgoing partons of the event
 	float nPUMean;        //< mean ("true") number of PU interactions
 	unsigned char nPUm2;  // bx = -2
 	unsigned char nPUm1;  // bx = -1

--- a/DataFormats/interface/KInfo.h
+++ b/DataFormats/interface/KInfo.h
@@ -113,6 +113,7 @@ struct KGenEventInfo : public KEventInfo
 	double weight;                      //< Monte-Carlo weight of the event
 	double binValue;                    //< ?
 	double alphaQCD;                    //< value of alpha_S for this event
+	double lheHt;                       //< p-T sum of the outgoing partons of the event
 	float nPUMean;        //< mean ("true") number of PU interactions
 	unsigned char nPUm2;  // bx = -2
 	unsigned char nPUm1;  // bx = -1

--- a/DataFormats/interface/KJetMET.h
+++ b/DataFormats/interface/KJetMET.h
@@ -51,6 +51,7 @@ struct KJet : public KBasicJet
 {
 	std::vector<float> tags;            //< float value tags (b-tag, etc.)
 	unsigned int binaryIds;             //< binary value tags (PU jet ID, etc.)
+	int partonFlavour, hadronFlavour;
 
 	float getTag(const std::string& name, const KJetMetadata *jetmetadata, bool check = true) const
 	{

--- a/DataFormats/interface/KJetMET.h
+++ b/DataFormats/interface/KJetMET.h
@@ -51,7 +51,7 @@ struct KJet : public KBasicJet
 {
 	std::vector<float> tags;            //< float value tags (b-tag, etc.)
 	unsigned int binaryIds;             //< binary value tags (PU jet ID, etc.)
-	int partonFlavour, hadronFlavour;
+	int flavour;
 
 	float getTag(const std::string& name, const KJetMetadata *jetmetadata, bool check = true) const
 	{

--- a/DataFormats/test/KDebug.cpp
+++ b/DataFormats/test/KDebug.cpp
@@ -130,7 +130,7 @@ std::ostream &operator<<(std::ostream &os, const KBasicJet &jet)
 std::ostream &operator<<(std::ostream &os, const KJet &jet)
 {
 	os << static_cast<const KBasicJet>(jet);
-	os << "\tflavour=" << jet.hadronFlavour;
+	os << "\tflavour=" << jet.flavour;
 	os << "\tIDs=" << std::bitset<8>(jet.binaryIds);
 	if (jet.tags.size() > 0)
 		os << std::endl << "\ttags: ";

--- a/DataFormats/test/KDebug.cpp
+++ b/DataFormats/test/KDebug.cpp
@@ -130,6 +130,7 @@ std::ostream &operator<<(std::ostream &os, const KBasicJet &jet)
 std::ostream &operator<<(std::ostream &os, const KJet &jet)
 {
 	os << static_cast<const KBasicJet>(jet);
+	os << "\tpartFlav=" << jet.partonFlavour << " hadrFlav=" << jet.hadronFlavour;
 	os << "\tIDs=" << std::bitset<8>(jet.binaryIds);
 	if (jet.tags.size() > 0)
 		os << std::endl << "\ttags: ";

--- a/DataFormats/test/KDebug.cpp
+++ b/DataFormats/test/KDebug.cpp
@@ -130,7 +130,7 @@ std::ostream &operator<<(std::ostream &os, const KBasicJet &jet)
 std::ostream &operator<<(std::ostream &os, const KJet &jet)
 {
 	os << static_cast<const KBasicJet>(jet);
-	os << "\tpartFlav=" << jet.partonFlavour << " hadrFlav=" << jet.hadronFlavour;
+	os << "\tflavour=" << jet.hadronFlavour;
 	os << "\tIDs=" << std::bitset<8>(jet.binaryIds);
 	if (jet.tags.size() > 0)
 		os << std::endl << "\ttags: ";

--- a/Producers/interface/KJetProducer.h
+++ b/Producers/interface/KJetProducer.h
@@ -160,8 +160,7 @@ public:
 		out.area = in.jetArea();
 		out.nConstituents = in.nConstituents();
 		out.nCharged = in.chargedMultiplicity();
-		out.partonFlavour = 0;
-		out.hadronFlavour = 0;
+		out.flavour = 0;
 
 		double sumFractions =
 			in.neutralHadronEnergyFraction() +

--- a/Producers/interface/KJetProducer.h
+++ b/Producers/interface/KJetProducer.h
@@ -160,6 +160,8 @@ public:
 		out.area = in.jetArea();
 		out.nConstituents = in.nConstituents();
 		out.nCharged = in.chargedMultiplicity();
+		out.partonFlavour = 0;
+		out.hadronFlavour = 0;
 
 		double sumFractions =
 			in.neutralHadronEnergyFraction() +

--- a/Producers/interface/KPatJetProducer.h
+++ b/Producers/interface/KPatJetProducer.h
@@ -67,6 +67,8 @@ public:
 		out.electronFraction = in.electronEnergyFraction();
 		out.hfHadronFraction = in.HFHadronEnergyFraction();
 		out.hfEMFraction = in.HFEMEnergyFraction();
+		out.partonFlavour = in.partonFlavour();
+		out.hadronFlavour = in.hadronFlavour();
 
 // energy fraction definitions have changed in CMSSW 7.3.X
 // fractions should add up to unity

--- a/Producers/interface/KPatJetProducer.h
+++ b/Producers/interface/KPatJetProducer.h
@@ -67,8 +67,7 @@ public:
 		out.electronFraction = in.electronEnergyFraction();
 		out.hfHadronFraction = in.HFHadronEnergyFraction();
 		out.hfEMFraction = in.HFEMEnergyFraction();
-		out.partonFlavour = in.partonFlavour();
-		out.hadronFlavour = in.hadronFlavour();
+		out.flavour = in.hadronFlavour();
 
 // energy fraction definitions have changed in CMSSW 7.3.X
 // fractions should add up to unity

--- a/Producers/python/KTuple_cff.py
+++ b/Producers/python/KTuple_cff.py
@@ -44,6 +44,7 @@ kappaTupleDefaultsBlock = cms.PSet(
 		genSource = cms.InputTag("generator"),
 		lumiSource = cms.InputTag("lumiProducer"),
 		pileUpInfoSource = cms.InputTag("addPileupInfo"),
+		lheSource = cms.InputTag("externalLHEProducer"),
 		isEmbedded = cms.bool(False),
 
 		l1Source = cms.InputTag("gtDigis"),

--- a/Producers/python/KTuple_cff.py
+++ b/Producers/python/KTuple_cff.py
@@ -46,6 +46,7 @@ kappaTupleDefaultsBlock = cms.PSet(
 		pileUpInfoSource = cms.InputTag("addPileupInfo"),
 		lheSource = cms.InputTag("externalLHEProducer"),
 		isEmbedded = cms.bool(False),
+		binningMode = cms.string("ht"),
 
 		l1Source = cms.InputTag("gtDigis"),
 		hltSource = cms.InputTag("TriggerResults"),


### PR DESCRIPTION
Hi Kappa users,

I created this pull request since the need of adding a couple of additional quantities to the Kappa dataformat showed up.
I started adding two new integer quantities for storing the jet flavour, relying on patJets methods, since apparently the way which was used so far is not optimal anymore.
@ffrensch could you please cross-check with Imperial that this is the quantity that they are actually using?I looked it up and these seemed the most reasonable to me, but better to be sure.
Since these methods are defined only for patJets, they are filled only in the KPatJetProducer, while in the KJetProducer they get default values. It seems to me that there is no other way around here, but please tell me if you have a better suggestion.

I will probably update this pull request ~soon to add another gen-level quantity (HT) which seems to be needed if one wants to reweight and stitch together some HT-samples which are available (see https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2015#MC_samples). I don't think that this information is available anywhere in Kappa, at the moment.

Normally these modifications should go in the dictchanges branch, since this is what they are. However, given that the master itself, right now, contains other dictchanges and we haven't tagged and done the next skim yet, I thought they could be added to the 2.1.0 release.
