### PR TITLE
Preselection

### DIFF
--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -52,7 +52,21 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	from Kappa.Skimming.KSkimming_template_cfg import process
 	## ------------------------------------------------------------------------
-	## Write out edmFile to allos unscheduled modules to work
+	# count number of events before doing anything elese
+	process.p *= process.nEventsTotal
+	process.p *= process.nNegEventsTotal
+
+	# produce selected collections and filter events with not even one Lepton
+	from Kappa.Skimming.KSkimming_preselection import do_preselection
+	do_preselection(process)
+	process.p *= process.goodEventFilter
+
+	process.selectedKappaTaus.cut = cms.string('pt > 20 && abs(eta) < 2.3') 
+	process.selectedKappaMuons.cut = cms.string('pt > 10 && abs(eta) < 2.4')
+	process.selectedKappaElectrons.cut = cms.string('pt > 13 && abs(eta) < 2.5 ')
+	process.goodEventFilter.minNumber = cms.uint32(2)
+	## ------------------------------------------------------------------------
+		# possibility to write out edmDump. Be careful when using unsceduled mode
 	process.load("Kappa.Skimming.edmOut")
 	#process.ep *= process.edmOut
 
@@ -68,15 +82,12 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	if not globaltag.lower() == 'auto' :
 		process.GlobalTag.globaltag   = globaltag
 		print "GT (overwritten):", process.GlobalTag.globaltag
-	process.ep *= process.kappaOut
 	## ------------------------------------------------------------------------
 	# Configure Metadata describing the file
 	# Important to be evaluated correctly for the following steps
 	process.kappaTuple.active = cms.vstring('TreeInfo')
 	data, isEmbedded, miniaod, process.kappaTuple.TreeInfo.parameters = datasetsHelper.getTreeInfo(nickname, globaltag, kappaTag)
 
-	process.p *= process.nEventsTotal
-	process.p *= process.nNegEventsTotal
 	## ------------------------------------------------------------------------
 	# General configuration
 	if ((cmssw_version_number.startswith("7_4") and split_cmssw_version[2] >= 14) or (cmssw_version_number.startswith("7_6"))):
@@ -389,6 +400,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	## ------------------------------------------------------------------------
 	## if needed adapt output filename
+	process.p *= process.kappaOut
 	if outputfilename != '':
 		process.kappaTuple.outputFile = cms.string('%s'%outputfilename)
 

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -82,6 +82,9 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	if not globaltag.lower() == 'auto' :
 		process.GlobalTag.globaltag   = globaltag
 		print "GT (overwritten):", process.GlobalTag.globaltag
+	muons = "selectedKappaMuons"
+	electrons = "selectedKappaElectrons"
+	taus = "selectedKappaTaus"
 	## ------------------------------------------------------------------------
 	# Configure Metadata describing the file
 	# Important to be evaluated correctly for the following steps
@@ -150,13 +153,14 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	## ------------------------------------------------------------------------
 	# Configure Muons
 	process.load("Kappa.Skimming.KMuons_miniAOD_cff")
-	process.kappaTuple.Muons.muons.src = cms.InputTag("slimmedMuons")
+	process.kappaTuple.Muons.muons.src = cms.InputTag(muons)
 	process.kappaTuple.Muons.muons.vertexcollection = cms.InputTag("offlineSlimmedPrimaryVertices")
 	process.kappaTuple.Muons.muons.srcMuonIsolationPF = cms.InputTag("")
 	process.kappaTuple.Muons.use03ConeForPfIso = cms.bool(True)
+	for src in [ "muPFIsoDepositCharged", "muPFIsoDepositChargedAll", "muPFIsoDepositNeutral", "muPFIsoDepositGamma", "muPFIsoDepositPU"]:
+		setattr(getattr(process, src), "src", cms.InputTag(muons))
 
 	process.kappaTuple.active += cms.vstring('Muons')
-	process.kappaTuple.Muons.minPt = cms.double(8.0)
 	process.p *= ( process.makeKappaMuons )
 
 	## ------------------------------------------------------------------------
@@ -177,7 +181,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 					"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values")
 
 
-	setupElectrons(process)
+	setupElectrons(process, electrons)
 	process.p *= ( process.makeKappaElectrons )
 	## ------------------------------------------------------------------------
 	process.kappaTuple.active += cms.vstring('PatTaus')
@@ -271,7 +275,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	jetCollection = "slimmedJets"
 	runMVAMET( process, jetCollectionPF = jetCollection)
 	process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
-	process.MVAMET.srcLeptons  = cms.VInputTag("slimmedMuons", "slimmedElectrons", "slimmedTaus") # to produce all possible combinations
+	process.MVAMET.srcLeptons  = cms.VInputTag(muons, electrons, taus) # to produce all possible combinations
 	process.MVAMET.requireOS = cms.bool(False)
 
 	## ------------------------------------------------------------------------

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -94,24 +94,22 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 		process.kappaTuple.Info.pileUpInfoSource = cms.InputTag("slimmedAddPileupInfo")
 
 	process.kappaTuple.active += cms.vstring('VertexSummary')            # save VertexSummary,
-	if miniaod:
-		process.load("Kappa.Skimming.KVertices_cff")
-		process.goodOfflinePrimaryVertices.src = cms.InputTag('offlineSlimmedPrimaryVertices')
-		process.p *= ( process.makeVertexes )
-		process.kappaTuple.VertexSummary.whitelist = cms.vstring('offlineSlimmedPrimaryVertices')  # save VertexSummary,
-		process.kappaTuple.VertexSummary.rename = cms.vstring('offlineSlimmedPrimaryVertices => goodOfflinePrimaryVerticesSummary')
-		if (cmssw_version_number.startswith("7_6")):
-			process.kappaTuple.VertexSummary.goodOfflinePrimaryVerticesSummary = cms.PSet(src=cms.InputTag("offlineSlimmedPrimaryVertices"))
 
-		process.kappaTuple.active += cms.vstring('TriggerObjectStandalone')
-		if(data and ("Run2015" in nickname)):
-			process.kappaTuple.TriggerObjectStandalone.metfilterbits = cms.InputTag("TriggerResults", "", "RECO")
+	process.load("Kappa.Skimming.KVertices_cff")
+	process.goodOfflinePrimaryVertices.src = cms.InputTag('offlineSlimmedPrimaryVertices')
+	process.p *= ( process.makeVertexes )
+	process.kappaTuple.VertexSummary.whitelist = cms.vstring('offlineSlimmedPrimaryVertices')  # save VertexSummary,
+	process.kappaTuple.VertexSummary.rename = cms.vstring('offlineSlimmedPrimaryVertices => goodOfflinePrimaryVerticesSummary')
+	if (cmssw_version_number.startswith("7_6")):
+		process.kappaTuple.VertexSummary.goodOfflinePrimaryVerticesSummary = cms.PSet(src=cms.InputTag("offlineSlimmedPrimaryVertices"))
+
+	process.kappaTuple.active += cms.vstring('TriggerObjectStandalone')
+	if(data and ("Run2015" in nickname)):
+		process.kappaTuple.TriggerObjectStandalone.metfilterbits = cms.InputTag("TriggerResults", "", "RECO")
 
 	process.kappaTuple.active += cms.vstring('BeamSpot')                 # save Beamspot,
 	if (cmssw_version_number.startswith("7_6")):
 		process.kappaTuple.BeamSpot.offlineBeamSpot = cms.PSet(src = cms.InputTag("offlineBeamSpot"))
-	if not miniaod:
-		process.kappaTuple.active += cms.vstring('TriggerObjects')
 
 	if not isEmbedded and data:
 			process.kappaTuple.active+= cms.vstring('DataInfo')          # produce Metadata for data,
@@ -121,15 +119,9 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 			process.kappaTuple.active+= cms.vstring('GenParticles')      # save GenParticles,
 			process.kappaTuple.active+= cms.vstring('GenTaus')           # save GenParticles,
 
-			if(miniaod):
-				process.kappaTuple.GenParticles.genParticles.src = cms.InputTag("prunedGenParticles")
-				process.kappaTuple.GenTaus.genTaus.src = cms.InputTag("prunedGenParticles")
-	# Prune genParticles
-	if not isEmbedded and not data and not miniaod:
-		process.load("Kappa.Skimming.PruneGenParticles_cff")
-	
-	# Special settings for embedded samples
-	# https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonTauReplacementWithPFlow
+			process.kappaTuple.GenParticles.genParticles.src = cms.InputTag("prunedGenParticles")
+			process.kappaTuple.GenTaus.genTaus.src = cms.InputTag("prunedGenParticles")
+
 	if isEmbedded:
 		#process.load('RecoBTag/Configuration/RecoBTag_cff')
 		#process.load('RecoJets/JetAssociationProducers/ak5JTA_cff')
@@ -150,35 +142,18 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.kappaTuple.Info.hltBlacklist = hltBlacklist
 
 	## ------------------------------------------------------------------------
-	# Configure PFCandidates and offline PV
-	if(not miniaod):
-		process.load("Kappa.Skimming.KPFCandidates_run2_cff")
-		process.kappaTuple.active += cms.vstring('PFCandidates') # save PFCandidates for deltaBeta corrected
-		process.kappaTuple.PFCandidates.whitelist = cms.vstring( # isolation used for electrons and muons.
-		##	"pfNoPileUpChargedHadrons",    ## switch to pfAllChargedParticles
-			"pfAllChargedParticles",       ## same as pfNoPileUpChargedHadrons +pf_electrons + pf_muons
-			"pfNoPileUpNeutralHadrons",
-			"pfNoPileUpPhotons",
-			"pfPileUpChargedHadrons",
-			)
-		##process.p *= ( process.makePFBRECO * process.makePFCandidatesForDeltaBeta )
-		process.p *= ( process.makeKappaPFCandidates )
 
-	if(miniaod):
-		process.kappaTuple.active += cms.vstring('packedPFCandidates') # save PFCandidates. Not sure for what, because might not be usefull for isolation
-		if (cmssw_version_number.startswith("7_6")):
-			process.kappaTuple.packedPFCandidates.packedPFCandidates = cms.PSet(src = cms.InputTag("packedPFCandidates"))
+	process.kappaTuple.active += cms.vstring('packedPFCandidates') # save PFCandidates. Not sure for what, because might not be usefull for isolation
+	if (cmssw_version_number.startswith("7_6")):
+		process.kappaTuple.packedPFCandidates.packedPFCandidates = cms.PSet(src = cms.InputTag("packedPFCandidates"))
 
 	## ------------------------------------------------------------------------
 	# Configure Muons
-	if not miniaod:
-		process.load("Kappa.Skimming.KMuons_run2_cff")
-	if(miniaod):
-		process.load("Kappa.Skimming.KMuons_miniAOD_cff")
-		process.kappaTuple.Muons.muons.src = cms.InputTag("slimmedMuons")
-		process.kappaTuple.Muons.muons.vertexcollection = cms.InputTag("offlineSlimmedPrimaryVertices")
-		process.kappaTuple.Muons.muons.srcMuonIsolationPF = cms.InputTag("")
-		process.kappaTuple.Muons.use03ConeForPfIso = cms.bool(True)
+	process.load("Kappa.Skimming.KMuons_miniAOD_cff")
+	process.kappaTuple.Muons.muons.src = cms.InputTag("slimmedMuons")
+	process.kappaTuple.Muons.muons.vertexcollection = cms.InputTag("offlineSlimmedPrimaryVertices")
+	process.kappaTuple.Muons.muons.srcMuonIsolationPF = cms.InputTag("")
+	process.kappaTuple.Muons.use03ConeForPfIso = cms.bool(True)
 
 	process.kappaTuple.active += cms.vstring('Muons')
 	process.kappaTuple.Muons.minPt = cms.double(8.0)
@@ -187,127 +162,84 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	## ------------------------------------------------------------------------
 	# Configure Electrons
 	process.kappaTuple.active += cms.vstring('Electrons')
-	if(miniaod):
-		process.load("Kappa.Skimming.KElectrons_miniAOD_cff")
-		process.kappaTuple.Electrons.electrons.src = cms.InputTag("slimmedElectrons")
-		process.kappaTuple.Electrons.electrons.vertexcollection = cms.InputTag("offlineSlimmedPrimaryVertices")
-		process.kappaTuple.Electrons.electrons.rhoIsoInputTag = cms.InputTag("slimmedJets", "rho")
-		process.kappaTuple.Electrons.electrons.allConversions = cms.InputTag("reducedEgamma", "reducedConversions")
-		from Kappa.Skimming.KElectrons_miniAOD_cff import setupElectrons
-		process.kappaTuple.Electrons.srcIds = cms.string("standalone");
+	process.load("Kappa.Skimming.KElectrons_miniAOD_cff")
+	process.kappaTuple.Electrons.electrons.src = cms.InputTag("slimmedElectrons")
+	process.kappaTuple.Electrons.electrons.vertexcollection = cms.InputTag("offlineSlimmedPrimaryVertices")
+	process.kappaTuple.Electrons.electrons.rhoIsoInputTag = cms.InputTag("slimmedJets", "rho")
+	process.kappaTuple.Electrons.electrons.allConversions = cms.InputTag("reducedEgamma", "reducedConversions")
+	from Kappa.Skimming.KElectrons_miniAOD_cff import setupElectrons
+	process.kappaTuple.Electrons.srcIds = cms.string("standalone");
 
-		process.kappaTuple.Electrons.ids = cms.vstring("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
-						"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
-						"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
-						"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight",
-						"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values")
+	process.kappaTuple.Electrons.ids = cms.vstring("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
+					"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
+					"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
+					"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight",
+					"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values")
 
-	if not miniaod:
-		process.load("Kappa.Skimming.KElectrons_run2_cff")
-		process.kappaTuple.Electrons.minPt = cms.double(8.0)
-		from Kappa.Skimming.KElectrons_run2_cff import setupElectrons
-
-		process.kappaTuple.Electrons.ids = cms.vstring("cutBasedElectronID_Spring15_25ns_V1_standalone_loose",
-						"cutBasedElectronID_Spring15_25ns_V1_standalone_medium",
-						"cutBasedElectronID_Spring15_25ns_V1_standalone_tight",
-						"cutBasedElectronID_Spring15_25ns_V1_standalone_veto",
-						"ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values")
 
 	setupElectrons(process)
 	process.p *= ( process.makeKappaElectrons )
 	## ------------------------------------------------------------------------
-	if(miniaod):
-		process.kappaTuple.active += cms.vstring('PatTaus')
-		process.kappaTuple.PatTaus.taus.binaryDiscrBlacklist = cms.vstring()
-		process.kappaTuple.PatTaus.taus.floatDiscrBlacklist = cms.vstring()
-		# just took everything from https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauIDRecommendation13TeV
-		process.kappaTuple.PatTaus.taus.preselectOnDiscriminators = cms.vstring ()
-		process.kappaTuple.PatTaus.taus.binaryDiscrWhitelist = cms.vstring(
-		                                                                       "decayModeFinding",
-		                                                                       "decayModeFindingNewDMs",
-		                                                                       "byLooseCombinedIsolationDeltaBetaCorr3Hits",
-		                                                                       "byMediumCombinedIsolationDeltaBetaCorr3Hits",
-		                                                                       "byTightCombinedIsolationDeltaBetaCorr3Hits",
-		                                                                       "byCombinedIsolationDeltaBetaCorrRaw3Hits",
-		                                                                       "chargedIsoPtSum",
-		                                                                       "neutralIsoPtSum",
-		                                                                       "puCorrPtSum",
-		                                                                       "footprintCorrection",
-		                                                                       "photonPtSumOutsideSignalCone",
-		                                                                       "byIsolationMVArun2v1DBoldDMwLTraw",
-		                                                                       "byLooseIsolationMVArun2v1DBoldDMwLT",
-		                                                                       "byMediumIsolationMVArun2v1DBoldDMwLT",
-		                                                                       "byTightIsolationMVArun2v1DBoldDMwLT",
-		                                                                       "byVTightIsolationMVArun2v1DBoldDMwLT",
-		                                                                       "byIsolationMVArun2v1DBnewDMwLTraw",
-		                                                                       "byLooseIsolationMVArun2v1DBnewDMwLT",
-		                                                                       "byMediumIsolationMVArun2v1DBnewDMwLT",
-		                                                                       "byTightIsolationMVArun2v1DBnewDMwLT",
-		                                                                       "byVTightIsolationMVArun2v1DBnewDMwLT",
-		                                                                       "againstMuonLoose3",
-		                                                                       "againstMuonTight3",
-		                                                                       "againstElectronMVA5category",
-		                                                                       "againstElectronMVA5raw",
-		                                                                       "againstElectronVLooseMVA5",
-		                                                                       "againstElectronLooseMVA5",
-		                                                                       "againstElectronMediumMVA5",
-		                                                                       "againstElectronTightMVA5",
-		                                                                       "againstElectronVTightMVA5",
-		                                                                       "againstElectronMVA6category",
-		                                                                       "againstElectronMVA6raw",
-		                                                                       "againstElectronVLooseMVA6",
-		                                                                       "againstElectronLooseMVA6",
-		                                                                       "againstElectronMediumMVA6",
-		                                                                       "againstElectronTightMVA6",
-		                                                                       "againstElectronVTightMVA6",
-		                                                                       "byLooseCombinedIsolationDeltaBetaCorr3HitsdR03",
-		                                                                       "byMediumCombinedIsolationDeltaBetaCorr3HitsdR03",
-		                                                                       "byTightCombinedIsolationDeltaBetaCorr3HitsdR03",
-		                                                                       "byLooseIsolationMVArun2v1DBdR03oldDMwLT",
-		                                                                       "byMediumIsolationMVArun2v1DBdR03oldDMwLT",
-		                                                                       "byTightIsolationMVArun2v1DBdR03oldDMwLT",
-		                                                                       "byVTightIsolationMVArun2v1DBdR03oldDMwLT"
-		)
-		process.kappaTuple.PatTaus.taus.floatDiscrWhitelist = process.kappaTuple.PatTaus.taus.binaryDiscrWhitelist
-	## ------------------------------------------------------------------------
-	# Configure Taus
-	if(not miniaod):
-		process.load("Kappa.Skimming.KTaus_run2_cff")
-		process.kappaTuple.active += cms.vstring('Taus')
-		process.kappaTuple.Taus.minPt = cms.double(8.0)
-		process.p *= ( process.makeKappaTaus )
-
-	# Reduced number of Tau discriminators
-	# The blacklist is to some degree arbitrary to get below 64 binaty tau discriminators
-	# - they may need to be changed as soon as 'official' discriminators for TauID 2014 will be published
-		process.kappaTuple.Taus.taus.binaryDiscrBlacklist = cms.vstring("^shrinkingCone.*", ".*PFlow$", ".*raw.*", ".*Raw.*", "^hpsPFTauDiscriminationByVLoose.*", "^hpsPFTauDiscriminationByVTight.*", "^hpsPFTauDiscriminationByMedium.*")
-		process.kappaTuple.Taus.taus.preselectOnDiscriminators = cms.vstring("hpsPFTauDiscriminationByDecayModeFindingNewDMs")
-
+	process.kappaTuple.active += cms.vstring('PatTaus')
+	process.kappaTuple.PatTaus.taus.binaryDiscrBlacklist = cms.vstring()
+	process.kappaTuple.PatTaus.taus.floatDiscrBlacklist = cms.vstring()
+	# just took everything from https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauIDRecommendation13TeV
+	process.kappaTuple.PatTaus.taus.preselectOnDiscriminators = cms.vstring ()
+	process.kappaTuple.PatTaus.taus.binaryDiscrWhitelist = cms.vstring(
+	                                                                       "decayModeFinding",
+	                                                                       "decayModeFindingNewDMs",
+	                                                                       "byLooseCombinedIsolationDeltaBetaCorr3Hits",
+	                                                                       "byMediumCombinedIsolationDeltaBetaCorr3Hits",
+	                                                                       "byTightCombinedIsolationDeltaBetaCorr3Hits",
+	                                                                       "byCombinedIsolationDeltaBetaCorrRaw3Hits",
+	                                                                       "chargedIsoPtSum",
+	                                                                       "neutralIsoPtSum",
+	                                                                       "puCorrPtSum",
+	                                                                       "footprintCorrection",
+	                                                                       "photonPtSumOutsideSignalCone",
+	                                                                       "byIsolationMVArun2v1DBoldDMwLTraw",
+	                                                                       "byLooseIsolationMVArun2v1DBoldDMwLT",
+	                                                                       "byMediumIsolationMVArun2v1DBoldDMwLT",
+	                                                                       "byTightIsolationMVArun2v1DBoldDMwLT",
+	                                                                       "byVTightIsolationMVArun2v1DBoldDMwLT",
+	                                                                       "byIsolationMVArun2v1DBnewDMwLTraw",
+	                                                                       "byLooseIsolationMVArun2v1DBnewDMwLT",
+	                                                                       "byMediumIsolationMVArun2v1DBnewDMwLT",
+	                                                                       "byTightIsolationMVArun2v1DBnewDMwLT",
+	                                                                       "byVTightIsolationMVArun2v1DBnewDMwLT",
+	                                                                       "againstMuonLoose3",
+	                                                                       "againstMuonTight3",
+	                                                                       "againstElectronMVA5category",
+	                                                                       "againstElectronMVA5raw",
+	                                                                       "againstElectronVLooseMVA5",
+	                                                                       "againstElectronLooseMVA5",
+	                                                                       "againstElectronMediumMVA5",
+	                                                                       "againstElectronTightMVA5",
+	                                                                       "againstElectronVTightMVA5",
+	                                                                       "againstElectronMVA6category",
+	                                                                       "againstElectronMVA6raw",
+	                                                                       "againstElectronVLooseMVA6",
+	                                                                       "againstElectronLooseMVA6",
+	                                                                       "againstElectronMediumMVA6",
+	                                                                       "againstElectronTightMVA6",
+	                                                                       "againstElectronVTightMVA6",
+	                                                                       "byLooseCombinedIsolationDeltaBetaCorr3HitsdR03",
+	                                                                       "byMediumCombinedIsolationDeltaBetaCorr3HitsdR03",
+	                                                                       "byTightCombinedIsolationDeltaBetaCorr3HitsdR03",
+	                                                                       "byLooseIsolationMVArun2v1DBdR03oldDMwLT",
+	                                                                       "byMediumIsolationMVArun2v1DBdR03oldDMwLT",
+	                                                                       "byTightIsolationMVArun2v1DBdR03oldDMwLT",
+	                                                                       "byVTightIsolationMVArun2v1DBdR03oldDMwLT"
+	)
+	process.kappaTuple.PatTaus.taus.floatDiscrWhitelist = process.kappaTuple.PatTaus.taus.binaryDiscrWhitelist
 	## ------------------------------------------------------------------------
 	## Configure Jets
 
 	process.kappaTuple.active += cms.vstring('PileupDensity')
-	if not miniaod:
-		process.load("Kappa.Skimming.KJets_run2_cff")
-		process.kappaTuple.active += cms.vstring('Jets')
-		process.kappaTuple.Jets = process.kappaTupleJets
-		process.kappaTuple.Jets.minPt = cms.double(10.0)
 
-		#Check if working
-		process.p *= (
-			process.ak4PFJetsCHScor *
-		#	process.makePFJets *
-		#	process.makePFJetsCHS *
-		#	process.makeQGTagging *
-		#	process.makeBTagging *
-		#	process.makePUJetID *
-			process.kt6PFJets
-		)
-
-	if miniaod:
-		process.kappaTuple.active += cms.vstring('PatJets')
-		if (cmssw_version_number.startswith("7_6")):
-			process.kappaTuple.PatJets.ak4PF = cms.PSet(src=cms.InputTag("slimmedJets"))
+	process.kappaTuple.active += cms.vstring('PatJets')
+	if (cmssw_version_number.startswith("7_6")):
+		process.kappaTuple.PatJets.ak4PF = cms.PSet(src=cms.InputTag("slimmedJets"))
 	if (cmssw_version_number.startswith("7_6")):
 		process.kappaTuple.PileupDensity.pileupDensity = cms.PSet(src=cms.InputTag("fixedGridRhoFastjetAll"))
 	process.kappaTuple.PileupDensity.whitelist = cms.vstring("fixedGridRhoFastjetAll")
@@ -317,55 +249,37 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	## ------------------------------------------------------------------------
 	## MET
 	process.load("Kappa.Skimming.KMET_run2_cff")
+	from Kappa.Skimming.KMET_run2_cff import configureMVAMetForMiniAOD
+	configureMVAMetForMiniAOD(process)
 
-	if (not miniaod):
-		from Kappa.Skimming.KMET_run2_cff import configureMVAMetForAOD
-		configureMVAMetForAOD(process)
-		process.kappaTuple.active += cms.vstring('GenMET')                  ## produce/save KappaMET
-		process.kappaTuple.active += cms.vstring('MET')                       ## produce/save KappaPFMET and MVA MET
-		## Write MVA MET to KMETs. To check what happens on AOD
-		process.kappaTuple.active += cms.vstring('PatMETs')
-		process.kappaTuple.PatMETs.whitelist = cms.vstring(
-		                                                   "metMVAEM",
-		                                                   "metMVAET",
-		                                                   "metMVAMT",
-		                                                   "metMVATT"
-		                                                    )
-		process.p *= process.makeKappaMET
+	## Standard MET and GenMet from pat::MET
+	process.kappaTuple.active += cms.vstring('PatMET')
+	process.kappaTuple.PatMET.met = cms.PSet(src=cms.InputTag("slimmedMETs"))
+	process.kappaTuple.PatMET.metPuppi = cms.PSet(src=cms.InputTag("slimmedMETsPuppi"))
 
-	if(miniaod):
-		from Kappa.Skimming.KMET_run2_cff import configureMVAMetForMiniAOD
-		configureMVAMetForMiniAOD(process)
+	## Write MVA MET to KMETs. To check what happens on AOD
+	process.kappaTuple.active += cms.vstring('PatMETs')
+	process.kappaTuple.PatMETs.metMVAEM = cms.PSet(src=cms.InputTag("metMVAEM"))
+	process.kappaTuple.PatMETs.metMVAET = cms.PSet(src=cms.InputTag("metMVAET"))
+	process.kappaTuple.PatMETs.metMVAMT = cms.PSet(src=cms.InputTag("metMVAMT"))
+	process.kappaTuple.PatMETs.metMVATT = cms.PSet(src=cms.InputTag("metMVATT"))
+	process.load('JetMETCorrections.Configuration.JetCorrectionServices_cff')
+	process.p *= (process.makeKappaMET)
 
-		## Standard MET and GenMet from pat::MET
-		process.kappaTuple.active += cms.vstring('PatMET')
-		process.kappaTuple.PatMET.met = cms.PSet(src=cms.InputTag("slimmedMETs"))
-		process.kappaTuple.PatMET.metPuppi = cms.PSet(src=cms.InputTag("slimmedMETsPuppi"))
-
-		## Write MVA MET to KMETs. To check what happens on AOD
-		process.kappaTuple.active += cms.vstring('PatMETs')
-		process.kappaTuple.PatMETs.metMVAEM = cms.PSet(src=cms.InputTag("metMVAEM"))
-		process.kappaTuple.PatMETs.metMVAET = cms.PSet(src=cms.InputTag("metMVAET"))
-		process.kappaTuple.PatMETs.metMVAMT = cms.PSet(src=cms.InputTag("metMVAMT"))
-		process.kappaTuple.PatMETs.metMVATT = cms.PSet(src=cms.InputTag("metMVATT"))
-		process.load('JetMETCorrections.Configuration.JetCorrectionServices_cff')
-		process.p *= (process.makeKappaMET)
-
-		# new MVA MET
-		from RecoMET.METPUSubtraction.MVAMETConfiguration_cff import runMVAMET
-		jetCollection = "slimmedJets"
-		runMVAMET( process, jetCollectionPF = jetCollection)
-		process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
-		process.MVAMET.srcLeptons  = cms.VInputTag("slimmedMuons", "slimmedElectrons", "slimmedTaus") # to produce all possible combinations
-		process.MVAMET.requireOS = cms.bool(False)
+	# new MVA MET
+	from RecoMET.METPUSubtraction.MVAMETConfiguration_cff import runMVAMET
+	jetCollection = "slimmedJets"
+	runMVAMET( process, jetCollectionPF = jetCollection)
+	process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
+	process.MVAMET.srcLeptons  = cms.VInputTag("slimmedMuons", "slimmedElectrons", "slimmedTaus") # to produce all possible combinations
+	process.MVAMET.requireOS = cms.bool(False)
 
 	## ------------------------------------------------------------------------
 	## GenJets 
 	if not data:
 		process.load('PhysicsTools/JetMCAlgos/TauGenJets_cfi')
 		process.load('PhysicsTools/JetMCAlgos/TauGenJetsDecayModeSelectorAllHadrons_cfi')
-		if(miniaod):
-			process.tauGenJets.GenParticles = cms.InputTag("prunedGenParticles")
+		process.tauGenJets.GenParticles = cms.InputTag("prunedGenParticles")
 		process.p *= ( 
 			process.tauGenJets +
 			process.tauGenJetsSelectorAllHadrons

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -38,6 +38,7 @@ options.register('testfile', '', VarParsing.multiplicity.singleton, VarParsing.v
 options.register('maxevents', -1, VarParsing.multiplicity.singleton, VarParsing.varType.int, 'maxevents')
 options.register('outputfilename', '', VarParsing.multiplicity.singleton, VarParsing.varType.string, 'Filename for the Outputfile')
 options.register('testsuite', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, 'Run the Kappa test suite. Default: True')
+options.register('preselect', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, 'apply preselection at CMSSW level on leptons')
 options.parseArguments()
 
 cmssw_version_number = tools.get_cmssw_version_number()
@@ -56,15 +57,22 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.p *= process.nEventsTotal
 	process.p *= process.nNegEventsTotal
 
+	muons = "slimmedMuons"
+	electrons = "slimmedElectrons"
+	taus = "slimmedTaus"
 	# produce selected collections and filter events with not even one Lepton
-	from Kappa.Skimming.KSkimming_preselection import do_preselection
-	do_preselection(process)
-	process.p *= process.goodEventFilter
+	if(options.preselection)
+		from Kappa.Skimming.KSkimming_preselection import do_preselection
+		do_preselection(process)
+		process.p *= process.goodEventFilter
 
-	process.selectedKappaTaus.cut = cms.string('pt > 8 && abs(eta) < 2.5') 
-	process.selectedKappaMuons.cut = cms.string('pt > 8 && abs(eta) < 2.6')
-	process.selectedKappaElectrons.cut = cms.string('pt > 8 && abs(eta) < 2.7')
-	process.goodEventFilter.minNumber = cms.uint32(2)
+		process.selectedKappaTaus.cut = cms.string('pt > 8 && abs(eta) < 2.5') 
+		process.selectedKappaMuons.cut = cms.string('pt > 8 && abs(eta) < 2.6')
+		process.selectedKappaElectrons.cut = cms.string('pt > 8 && abs(eta) < 2.7')
+		process.goodEventFilter.minNumber = cms.uint32(2)
+		muons = "selectedKappaMuons"
+		electrons = "selectedKappaElectrons"
+		taus = "selectedKappaTaus"
 	## ------------------------------------------------------------------------
 		# possibility to write out edmDump. Be careful when using unsceduled mode
 	process.load("Kappa.Skimming.edmOut")
@@ -82,9 +90,6 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	if not globaltag.lower() == 'auto' :
 		process.GlobalTag.globaltag   = globaltag
 		print "GT (overwritten):", process.GlobalTag.globaltag
-	muons = "selectedKappaMuons"
-	electrons = "selectedKappaElectrons"
-	taus = "selectedKappaTaus"
 	## ------------------------------------------------------------------------
 	# Configure Metadata describing the file
 	# Important to be evaluated correctly for the following steps
@@ -313,7 +318,6 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 		process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
 		process.MVAMET.srcLeptons  = cms.VInputTag("slimmedMuons", "slimmedElectrons", "slimmedTaus") # to produce all possible combinations
 		process.MVAMET.requireOS = cms.bool(False)
->>>>>>> CMSSW_7_6_X
 
 	## ------------------------------------------------------------------------
 	## GenJets 

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -61,9 +61,9 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	do_preselection(process)
 	process.p *= process.goodEventFilter
 
-	process.selectedKappaTaus.cut = cms.string('pt > 20 && abs(eta) < 2.3') 
-	process.selectedKappaMuons.cut = cms.string('pt > 10 && abs(eta) < 2.4')
-	process.selectedKappaElectrons.cut = cms.string('pt > 13 && abs(eta) < 2.5 ')
+	process.selectedKappaTaus.cut = cms.string('pt > 8 && abs(eta) < 2.5') 
+	process.selectedKappaMuons.cut = cms.string('pt > 8 && abs(eta) < 2.6')
+	process.selectedKappaElectrons.cut = cms.string('pt > 8 && abs(eta) < 2.7')
 	process.goodEventFilter.minNumber = cms.uint32(2)
 	## ------------------------------------------------------------------------
 		# possibility to write out edmDump. Be careful when using unsceduled mode

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -146,9 +146,8 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	## ------------------------------------------------------------------------
 
-	process.kappaTuple.active += cms.vstring('packedPFCandidates') # save PFCandidates. Not sure for what, because might not be usefull for isolation
-	if (cmssw_version_number.startswith("7_6")):
-		process.kappaTuple.packedPFCandidates.packedPFCandidates = cms.PSet(src = cms.InputTag("packedPFCandidates"))
+	#process.kappaTuple.active += cms.vstring('packedPFCandidates') # save PFCandidates. Not sure for what, because might not be usefull for isolation
+	#process.kappaTuple.packedPFCandidates.packedPFCandidates = cms.PSet(src = cms.InputTag("packedPFCandidates"))
 
 	## ------------------------------------------------------------------------
 	# Configure Muons

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -248,8 +248,11 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.kappaTuple.PatTaus.taus.floatDiscrWhitelist = process.kappaTuple.PatTaus.taus.binaryDiscrWhitelist
 	## ------------------------------------------------------------------------
 	## Configure Jets
-
 	process.kappaTuple.active += cms.vstring('PileupDensity')
+	process.kappaTuple.PileupDensity.whitelist = cms.vstring("fixedGridRhoFastjetAll")
+	process.kappaTuple.PileupDensity.rename = cms.vstring("fixedGridRhoFastjetAll => pileupDensity")
+	if (cmssw_version_number.startswith("7_6")):
+		process.kappaTuple.PileupDensity.pileupDensity = cms.PSet(src=cms.InputTag("fixedGridRhoFastjetAll"))
 	process.kappaTuple.active += cms.vstring('PatJets')
 	if (cmssw_version_number.startswith("7_6")):
 		process.kappaTuple.PatJets.ak4PF = cms.PSet(src=cms.InputTag(jetCollection))

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -66,7 +66,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 		do_preselection(process)
 		process.p *= process.goodEventFilter
 
-		process.selectedKappaTaus.cut = cms.string('pt > 8 && abs(eta) < 2.5') 
+		process.selectedKappaTaus.cut = cms.string('pt > 15 && abs(eta) < 2.5') 
 		process.selectedKappaMuons.cut = cms.string('pt > 8 && abs(eta) < 2.6')
 		process.selectedKappaElectrons.cut = cms.string('pt > 8 && abs(eta) < 2.7')
 		process.goodEventFilter.minNumber = cms.uint32(2)

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -61,7 +61,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	electrons = "slimmedElectrons"
 	taus = "slimmedTaus"
 	# produce selected collections and filter events with not even one Lepton
-	if(options.preselection)
+	if(options.preselect):
 		from Kappa.Skimming.KSkimming_preselection import do_preselection
 		do_preselection(process)
 		process.p *= process.goodEventFilter
@@ -253,71 +253,24 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.kappaTuple.active += cms.vstring('PatJets')
 	if (cmssw_version_number.startswith("7_6")):
 		process.kappaTuple.PatJets.ak4PF = cms.PSet(src=cms.InputTag(jetCollection))
-	from Kappa.Skimming.KMET_run2_cff import configureMVAMetForMiniAOD
-	configureMVAMetForMiniAOD(process)
+	#from Kappa.Skimming.KMET_run2_cff import configureMVAMetForMiniAOD
+	#configureMVAMetForMiniAOD(process)
 
 	## Standard MET and GenMet from pat::MET
 	process.kappaTuple.active += cms.vstring('PatMET')
 	process.kappaTuple.PatMET.met = cms.PSet(src=cms.InputTag("slimmedMETs"))
+	process.kappaTuple.PatMET.pfmetT1 = cms.PSet(src=cms.InputTag("patpfMETT1"))
 	process.kappaTuple.PatMET.metPuppi = cms.PSet(src=cms.InputTag("slimmedMETsPuppi"))
 
-	## Write MVA MET to KMETs. To check what happens on AOD
+	## Write MVA MET to KMETs
 	process.kappaTuple.active += cms.vstring('PatMETs')
-	process.kappaTuple.PatMETs.metMVAEM = cms.PSet(src=cms.InputTag("metMVAEM"))
-	process.kappaTuple.PatMETs.metMVAET = cms.PSet(src=cms.InputTag("metMVAET"))
-	process.kappaTuple.PatMETs.metMVAMT = cms.PSet(src=cms.InputTag("metMVAMT"))
-	process.kappaTuple.PatMETs.metMVATT = cms.PSet(src=cms.InputTag("metMVATT"))
-	process.load('JetMETCorrections.Configuration.JetCorrectionServices_cff')
-	process.p *= (process.makeKappaMET)
-
 	# new MVA MET
 	from RecoMET.METPUSubtraction.MVAMETConfiguration_cff import runMVAMET
-	jetCollection = "slimmedJets"
 	runMVAMET( process, jetCollectionPF = jetCollection)
 	process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
 	process.MVAMET.srcLeptons  = cms.VInputTag(muons, electrons, taus) # to produce all possible combinations
 	process.MVAMET.requireOS = cms.bool(False)
-=======
 
-	if (not miniaod):
-		from Kappa.Skimming.KMET_run2_cff import configureMVAMetForAOD
-		configureMVAMetForAOD(process)
-		process.kappaTuple.active += cms.vstring('GenMET')                  ## produce/save KappaMET
-		process.kappaTuple.active += cms.vstring('MET')                       ## produce/save KappaPFMET and MVA MET
-		## Write MVA MET to KMETs. To check what happens on AOD
-		process.kappaTuple.active += cms.vstring('PatMETs')
-		process.kappaTuple.PatMETs.whitelist = cms.vstring(
-		                                                   "metMVAEM",
-		                                                   "metMVAET",
-		                                                   "metMVAMT",
-		                                                   "metMVATT"
-		                                                    )
-		process.p *= process.makeKappaMET
-
-	if(miniaod):
-		from Kappa.Skimming.KMET_run2_cff import configureMVAMetForMiniAOD
-		configureMVAMetForMiniAOD(process)
-
-		## Standard MET and GenMet from pat::MET
-		process.kappaTuple.active += cms.vstring('PatMET')
-		process.kappaTuple.PatMET.met = cms.PSet(src=cms.InputTag("slimmedMETs"))
-		process.kappaTuple.PatMET.metPuppi = cms.PSet(src=cms.InputTag("slimmedMETsPuppi"))
-
-		## Write MVA MET to KMETs. To check what happens on AOD
-		process.kappaTuple.active += cms.vstring('PatMETs')
-		process.kappaTuple.PatMETs.metMVAEM = cms.PSet(src=cms.InputTag("metMVAEM"))
-		process.kappaTuple.PatMETs.metMVAET = cms.PSet(src=cms.InputTag("metMVAET"))
-		process.kappaTuple.PatMETs.metMVAMT = cms.PSet(src=cms.InputTag("metMVAMT"))
-		process.kappaTuple.PatMETs.metMVATT = cms.PSet(src=cms.InputTag("metMVATT"))
-		process.load('JetMETCorrections.Configuration.JetCorrectionServices_cff')
-		process.p *= (process.makeKappaMET)
-
-		# new MVA MET
-		from RecoMET.METPUSubtraction.MVAMETConfiguration_cff import runMVAMET
-		runMVAMET( process, jetCollectionPF = jetCollection)
-		process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
-		process.MVAMET.srcLeptons  = cms.VInputTag("slimmedMuons", "slimmedElectrons", "slimmedTaus") # to produce all possible combinations
-		process.MVAMET.requireOS = cms.bool(False)
 
 	## ------------------------------------------------------------------------
 	## GenJets 

--- a/Skimming/python/KElectrons_miniAOD_cff.py
+++ b/Skimming/python/KElectrons_miniAOD_cff.py
@@ -11,14 +11,19 @@ from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDElectronIdProducer, DataFormat
 from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import *
 
-egmGsfElectronIDs.physicsObjectSrc = cms.InputTag('slimmedElectrons')
 
-def setupElectrons(process):
+def setupElectrons(process, electrons):
+	egmGsfElectronIDs.physicsObjectSrc = cms.InputTag(electrons)
 	switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 	my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
 			 'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff']
 	for idmod in my_id_modules:
 		setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+	process.elPFIsoDepositCharged.src = cms.InputTag(electrons)
+	process.elPFIsoDepositChargedAll.src = cms.InputTag(electrons)
+	process.elPFIsoDepositNeutral.src = cms.InputTag(electrons)
+	process.elPFIsoDepositGamma.src = cms.InputTag(electrons)
+	process.elPFIsoDepositPU.src = cms.InputTag(electrons)
 
 ## for electron iso
 from CommonTools.ParticleFlow.Isolation.pfElectronIsolation_cff import *
@@ -41,11 +46,6 @@ electronPFIsolationValuesSequence = cms.Sequence(
 	elPFIsoValueNeutral03PFIdPFIso+
 	elPFIsoValuePU03PFIdPFIso
 )
-elPFIsoDepositCharged.src = cms.InputTag("slimmedElectrons")
-elPFIsoDepositChargedAll.src = cms.InputTag("slimmedElectrons")
-elPFIsoDepositNeutral.src = cms.InputTag("slimmedElectrons")
-elPFIsoDepositGamma.src = cms.InputTag("slimmedElectrons")
-elPFIsoDepositPU.src = cms.InputTag("slimmedElectrons")
 elPFIsoDepositGamma.ExtractorPSet.ComponentName = cms.string("CandViewExtractor")
 
 # electron/muon PF iso sequence

--- a/Skimming/python/KSkimming_preselection.py
+++ b/Skimming/python/KSkimming_preselection.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+def do_preselection(process):
+	process.selectedKappaTaus = cms.EDFilter("PATTauSelector", 
+										src = cms.InputTag("slimmedTaus"),
+										filter = cms.bool(False),
+										cut = cms.string('pt > 20 && abs(eta) < 2.3') )
+	process.selectedKappaMuons = cms.EDFilter("PATMuonSelector", 
+										src = cms.InputTag("slimmedMuons"),
+										filter = cms.bool(False),
+										cut = cms.string('pt > 10 && abs(eta) < 2.4') )
+	process.selectedKappaElectrons = cms.EDFilter("PATElectronSelector", 
+										src = cms.InputTag("slimmedElectrons"),
+										filter = cms.bool(False),
+										cut = cms.string('pt > 13 && abs(eta) < 2.5 ') )
+	process.allKappaLeptons = cms.EDProducer("CandViewMerger",
+										src = cms.VInputTag("selectedKappaTaus", "selectedKappaMuons", "selectedKappaElectrons") )
+	process.goodEventFilter = cms.EDFilter("CandViewCountFilter",
+										src = cms.InputTag("allKappaLeptons"),
+										minNumber = cms.uint32(2),
+										filter = cms.bool(True) )

--- a/Skimming/python/KSkimming_template_cfg.py
+++ b/Skimming/python/KSkimming_template_cfg.py
@@ -59,6 +59,5 @@ process.kappaTuple.active = cms.vstring()
 process.kappaOut = cms.Sequence(process.kappaTuple)
 
 process.p = cms.Path ()
-process.ep = cms.EndPath()
 process.load("Kappa.CMSSW.EventWeightCountProducer_cff")
 


### PR DESCRIPTION
Cleanup of Higgs config file:
- miniaod vs. aod flags removed (that's why so many lines have been touched)
- drop packedPFCandidates
- only use preselected leptons
- require at least two preselected leptons, otherwise drop this event

Performance on 1000 Events on DY sample:
kappaTuple.root size: 1.9 MB vs. 14 MB
runtime: only 517 events have to be saved, Filling the tree speeds up from 3.2 to 0.7 ms/Event
