### PR TITLE
by default do not use noPropagation

### DIFF
--- a/Producers/interface/KMuonProducer.h
+++ b/Producers/interface/KMuonProducer.h
@@ -75,7 +75,8 @@ public:
 
 	virtual bool onLumi(const edm::LuminosityBlock &lumiBlock, const edm::EventSetup &setup)
 	{
-		propagatorToMuonSystem.init(setup);
+		if(!noPropagation)
+			propagatorToMuonSystem.init(setup);
 
 		muonMetadata->hltNames.clear();
 		muonTriggerObjectBitMap.clear();

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -177,6 +177,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	process.kappaTuple.active += cms.vstring('Muons')
 	process.kappaTuple.Muons.minPt = cms.double(8.0)
+	process.kappaTuple.Muons.noPropagation = cms.bool(True)
 	process.p *= ( process.makeKappaMuons )
 
 	## ------------------------------------------------------------------------


### PR DESCRIPTION
Dear all,

I spotted that the Muon part of Kappa takes a long time per lumi section to start up because of this "noPropagation". I don't know what it's designed to be used for, but the _propagated things do not seem to be used in the H2Taus analysis. Does anyone mind deactivating it? Speedup on the level of 200 events is 20%.

Cheers,
Raphael
