### PR TITLE
Polymorphic dataformat types

### DIFF
--- a/DataFormats/interface/KBasic.h
+++ b/DataFormats/interface/KBasic.h
@@ -19,6 +19,8 @@
 
 struct KLV
 {
+	virtual ~KLV() {};
+
 	RMFLV p4;
 };
 typedef std::vector<KLV> KLVs;
@@ -26,6 +28,8 @@ typedef std::vector<KLV> KLVs;
 
 struct KBeamSpot
 {
+	virtual ~KBeamSpot() {};
+
 	RMPoint position;              ///< position of the beam spot
 	char type;                     ///< type of beam (usually unknown): Unknown=-1, Fake=0, LHC=1, Tracker=2
 
@@ -43,6 +47,8 @@ typedef std::vector<KBeamSpot> KBeamSpots;
 
 struct KVertex
 {
+	virtual ~KVertex() {};
+
 	RMPoint position;
 	bool valid;
 	unsigned int nTracks;
@@ -58,6 +64,8 @@ typedef std::vector<KVertex> KVertices;
 
 struct KVertexSummary
 {
+	virtual ~KVertexSummary() {};
+
 	KVertex pv;
 	unsigned int nVertices;
 };
@@ -65,6 +73,8 @@ struct KVertexSummary
 
 struct KTaupairVerticesMap
 {
+	virtual ~KTaupairVerticesMap() {};
+
 	std::vector<int> diTauKey;
 	std::vector<KVertex> vertices;
 };
@@ -73,6 +83,8 @@ typedef std::vector<KTaupairVerticesMap> KTaupairVerticesMaps;
 
 struct KHit
 {
+	virtual ~KHit() {};
+
 	double theta, phi, pAbs, energyLoss;
 };
 typedef std::vector<KHit> KHits;
@@ -80,6 +92,8 @@ typedef std::vector<KHit> KHits;
 
 struct KTriggerObjectMetadata
 {
+	virtual ~KTriggerObjectMetadata() {};
+
 	std::string menu;
 	
 	/// { hlt1:filter1, ..., hlt1:filterN1, hlt2:filter1, ..., hlt2:filterN2, ...}
@@ -126,6 +140,8 @@ struct KTriggerObjectMetadata
 
 struct KTriggerObjects
 {
+	virtual ~KTriggerObjects() {};
+
 	KLVs trgObjects;
 	int metFilterBits;
 	/// { hlt1:idxFilter1, ..., hlt1:idxFilterN1, hlt2:idxFilter1, ..., hlt2:idxFilterN2, ...}
@@ -141,6 +157,8 @@ struct KTriggerObjects
 
 struct KFilterMetadata
 {
+	virtual ~KFilterMetadata() {};
+
 	std::vector<std::string> filternames;
 	unsigned int nEventsTotal;
 	unsigned int nNegEventsTotal;
@@ -150,6 +168,8 @@ struct KFilterMetadata
 
 struct KFilterSummary
 {
+	virtual ~KFilterSummary() {};
+
 	unsigned long presence;
 	unsigned long decision;
 

--- a/DataFormats/interface/KElectron.h
+++ b/DataFormats/interface/KElectron.h
@@ -12,6 +12,8 @@
 
 struct KElectronMetadata
 {
+	virtual ~KElectronMetadata() {};
+
 	std::vector<std::string> idNames;  //< names of configurable electron IDs
 };
 
@@ -31,6 +33,8 @@ namespace KElectronType { enum Type
 
 struct KElectron : public KLepton
 {
+	virtual ~KElectron() {};
+
 	/// identification results
 	std::vector<float> electronIds; //< configurable electron IDs (mainly for MVA IDs)
 

--- a/DataFormats/interface/KInfo.h
+++ b/DataFormats/interface/KInfo.h
@@ -18,6 +18,8 @@
 /// Provenance information to trace back the branch content to the corresponding EDM product
 struct KProvenance
 {
+	virtual ~KProvenance() {};
+
 	std::vector<std::string> names;         //< product names of the objects in EDM
 	std::vector<std::string> branches;      //< branch names in the Events tree in the same ordering
 };
@@ -28,6 +30,8 @@ const unsigned int KLFPrescaleError = 1 << 0;
 
 struct KLumiInfo
 {
+	virtual ~KLumiInfo() {};
+
 	unsigned int nLumi;                     //< lumi section number
 	unsigned int nRun;                      //< run number
 	unsigned int bitsUserFlags;             //< contains a flag for prescale errors
@@ -38,6 +42,8 @@ struct KLumiInfo
 
 struct KGenLumiInfo : public KLumiInfo
 {
+	virtual ~KGenLumiInfo() {};
+
 	double filterEff;              //< generator filter efficiency
 	double xSectionExt;            //< external process cross section
 	double xSectionInt;            //< internal process cross section
@@ -45,6 +51,8 @@ struct KGenLumiInfo : public KLumiInfo
 
 struct KDataLumiInfo : public KLumiInfo
 {
+	virtual ~KDataLumiInfo() {};
+
 	float avgInsDelLumi;           //< average of the instantaneous delivered luminosity
 	float avgInsDelLumiErr;        //< error on the average of the instantaneous delivered luminosity
 	float avgInsRecLumi;           //< average of the instantaneous recorded luminosity
@@ -72,6 +80,8 @@ const unsigned int KEFRecoWarnings = 1 << 4;
 
 struct KEventInfo
 {
+	virtual ~KEventInfo() {};
+
 	unsigned long long bitsL1;     //< trigger bits for the L1 trigger
 	unsigned long long bitsHLT;    //< trigger bits for the HLT trigger according to hltNames
 	unsigned long long nEvent;     //< event number
@@ -110,6 +120,8 @@ typedef int bx_id;
 
 struct KGenEventInfo : public KEventInfo
 {
+	virtual ~KGenEventInfo() {};
+
 	double weight;                      //< Monte-Carlo weight of the event
 	double binValue;                    //< ?
 	double alphaQCD;                    //< value of alpha_S for this event

--- a/DataFormats/interface/KJetMET.h
+++ b/DataFormats/interface/KJetMET.h
@@ -16,6 +16,8 @@
 
 struct KCaloJet : public KLV
 {
+	virtual ~KCaloJet() {};
+
 	float area;          //< jet area
 
 	float fEM;           //< energy fraction in the ECAL
@@ -30,6 +32,8 @@ typedef std::vector<KCaloJet> KCaloJets;
 
 struct KBasicJet : public KLV
 {
+	virtual ~KBasicJet() {};
+
 	float area;
 	float correction;
 
@@ -43,12 +47,16 @@ typedef std::vector<KBasicJet> KBasicJets;
 
 struct KJetMetadata
 {
+	virtual ~KJetMetadata() {};
+
 	std::vector<std::string> tagNames;  //< names of the float value taggers
 	std::vector<std::string> idNames;   //< names of the binary value IDs
 };
 
 struct KJet : public KBasicJet
 {
+	virtual ~KJet() {};
+
 	std::vector<float> tags;            //< float value tags (b-tag, etc.)
 	unsigned int binaryIds;             //< binary value tags (PU jet ID, etc.)
 	int flavour;
@@ -94,12 +102,16 @@ typedef std::vector<KJet> KJets;
 /// This gen jet dataformat is a private one for tau POG studies and might not be stable in future
 struct KGenJet : public KLV
 {
+	virtual ~KGenJet() {};
+
 	int genTauDecayMode;
 };
 typedef std::vector<KGenJet> KGenJets;
 
 struct KMET : public KLV
 {
+	virtual ~KMET() {};
+
 	double sumEt;
 	float photonFraction, electronFraction;
 	float neutralHadronFraction, chargedHadronFraction;
@@ -113,6 +125,8 @@ typedef std::vector<KMET> KMETs;
 
 struct KHCALNoiseSummary
 {
+	virtual ~KHCALNoiseSummary() {};
+
 	bool hasBadRBXTS4TS5;
 	float isolatedNoiseSumE;
 	float isolatedNoiseSumEt;
@@ -130,6 +144,8 @@ struct KHCALNoiseSummary
 
 struct KPileupDensity
 {
+	virtual ~KPileupDensity() {};
+
 	double rho;
 	double sigma;
 };

--- a/DataFormats/interface/KLepton.h
+++ b/DataFormats/interface/KLepton.h
@@ -34,6 +34,8 @@ namespace KLeptonId { enum Type
 
 struct KLepton : public KLV
 {
+	virtual ~KLepton() {};
+
 	unsigned char leptonInfo;  //< bitset containing the flavour, charge and user bits
 	unsigned char ids;         //< most relevant IDs of the lepton
 	float sumChargedHadronPt;  //< sum pt of charged hadrons for isolation
@@ -95,6 +97,8 @@ typedef std::vector<KLepton> KLeptons;
 
 struct KLeptonPair
 {
+	virtual ~KLeptonPair() {};
+
 	unsigned int hashLepton1;
 	unsigned int hashLepton2;
 	

--- a/DataFormats/interface/KMuon.h
+++ b/DataFormats/interface/KMuon.h
@@ -47,11 +47,15 @@ enum KGoodMuonType
 
 struct KMuonMetadata
 {
+	virtual ~KMuonMetadata() {};
+
 	std::vector<std::string> hltNames;  //< names of available HLT paths
 };
 
 struct KMuon : public KLepton
 {
+	virtual ~KMuon() {};
+
 	/// global track in addition to KLepton track == innerTrack, no outer or best track
 	KTrack globalTrack;
 
@@ -123,6 +127,8 @@ typedef std::vector<KMuon> KMuons;
 
 struct KL1Muon : public KLV
 {
+	virtual ~KL1Muon() {};
+
 	// bit    meaning
 	// 0-2    quality
 	// 3      isForward

--- a/DataFormats/interface/KParticle.h
+++ b/DataFormats/interface/KParticle.h
@@ -9,6 +9,8 @@
 /// Particle base class for generator particles or candidates
 struct KParticle : public KLV
 {
+	virtual ~KParticle() {};
+
 	/// bitset containing the status and the signed PDG-ID
 	int pdgId;  ///< PDG-ID of the particle
 
@@ -96,6 +98,8 @@ const unsigned int KGenParticleCustomMask = 1023u << KGenParticleCustomPosition;
 /// Generator particle
 struct KGenParticle : public KParticle
 {
+	virtual ~KGenParticle() {};
+
 	unsigned int particleinfo;
 	std::vector<unsigned int> daughterIndices;
 
@@ -139,6 +143,8 @@ typedef std::vector<KGenParticle> KGenParticles;
 /// Generator photon
 struct KGenPhoton : public KLV
 {
+	virtual ~KGenPhoton() {};
+
 	KLV mother;
 	char type;
 	bool isPhoton() const { return (type == 1); }
@@ -150,6 +156,8 @@ typedef std::vector<KGenPhoton> KGenPhotons;
 /// Generator tau
 struct KGenTau : public KGenParticle
 {
+	virtual ~KGenTau() {};
+
 	KLV visible;              //< momentum four-vector of visible particles
 	RMPoint vertex;           //< vertex
 
@@ -184,6 +192,8 @@ typedef std::vector<KGenTau> KGenTaus;
 /// Particle-Flow Candidate
 struct KPFCandidate : public KParticle
 {
+	virtual ~KPFCandidate() {};
+
 	double deltaP;            //< momentum difference?
 	double ecalEnergy;        //< energy deposited in ECAL
 	double hcalEnergy;        //< energy deposited in HCAL

--- a/DataFormats/interface/KPhoton.h
+++ b/DataFormats/interface/KPhoton.h
@@ -19,6 +19,8 @@ namespace KPhotonId { enum Type
 /// Photon dataformat
 struct KPhoton : public KLV
 {
+	virtual ~KPhoton() {};
+
 	unsigned char ids;         ///< most relevant IDs of the photon
 	float sumChargedHadronPt;  ///< sum pt of charged hadrons for isolation
 	float sumNeutralHadronEt;  ///< sum Et of neutral hadrons for isolation

--- a/DataFormats/interface/KTau.h
+++ b/DataFormats/interface/KTau.h
@@ -14,6 +14,8 @@
 
 struct KTauMetadata
 {
+	virtual ~KTauMetadata() {};
+
 	std::vector<std::string> binaryDiscriminatorNames; ///< names of tau discriminators with binary values
 	std::vector<std::string> floatDiscriminatorNames;  ///< names of tau discriminators with real (float) values
 };
@@ -24,6 +26,8 @@ struct KTauMetadata
  */
 struct KBasicTau : public KLepton
 {
+	virtual ~KBasicTau() {};
+
 	int decayMode;     ///< hadronic decay mode as identified by HPS algorithm
 	float emFraction;  ///< electromagnetic energy fraction
 
@@ -57,6 +61,8 @@ typedef std::vector<KBasicTau> KBasicTaus;
 /** copy from DataFormats/TauReco/interface/PFTau.h */
 struct KTau : public KBasicTau
 {
+	virtual ~KTau() {};
+
 	/// four-vectors and full PFCandidates
 	KLVs piZeroCandidates;
 	KPFCandidates chargedHadronCandidates;
@@ -78,6 +84,8 @@ typedef std::vector<KTau> KTaus;
  */
 struct KExtendedTau : public KTau
 {
+	virtual ~KExtendedTau() {};
+
 	/// four-vectors
 	KLVs superClusterBarrelCandidates;
 	KLVs superClusterEndcapCandidates;

--- a/DataFormats/interface/KTrack.h
+++ b/DataFormats/interface/KTrack.h
@@ -31,6 +31,8 @@ enum KTrackQualityType
     copy from DataFormats/TrackReco/interface/Track.h */
 struct KTrack : public KLV
 {
+	virtual ~KTrack() {};
+
 	/// reference point (formerly known as "vertex", not the PV)
 	RMPoint ref;
 
@@ -177,6 +179,8 @@ typedef std::vector<KTrack> KTracks;
 
 struct KMuonTriggerCandidate : public KTrack
 {
+	virtual ~KMuonTriggerCandidate() {};
+
 	bool isoDecision;
 	float isoQuantity;
 };
@@ -189,6 +193,8 @@ const unsigned char KLeptonPFMask = 1 << 4;
 
 struct KTrackSummary
 {
+	virtual ~KTrackSummary() {};
+
 	unsigned int nTracks;    //< number of tracks in the event
 	unsigned int nTracksHQ;  //< number of high quality tracks in the event
 };


### PR DESCRIPTION
I would like to request that somebody could merge this branch into the master. See issue https://github.com/KappaAnalysis/Kappa/issues/23 for a more detailed discussion. I made sure, that it compiles (both for skimming with scram b and for the analysis with make) and that the skim yields the same results and that Artus can read the resulting root files.

A small comment: Comparing old and new skim outputs, I get the following warnings using compareRootFiles.py

> CRITICAL: different leaf value: 0.000164987126482, 4.58673013343e-41 for name genmetTrue.electronFraction (compareRootFiles.py: line 293)
> CRITICAL: different leaf value: 6.74220479487e+22, 2.62236765636e-09 for name genmetTrue.muonFraction (compareRootFiles.py: line 293)
> CRITICAL: different leaf value: 3.08655346699e+29, 96325632.0 for name genmetTrue.photonFraction (compareRootFiles.py: line 293)

I looked into the KGenMETProducer and understood, that these branches are just not filled. So I guess we sweep these differences under the carpet, arguing that ROOT will compress it away.
