### PR TITLE
Added option to uncorrect MET. This is done in Excalibur for calib

### DIFF
--- a/Producers/interface/KPatMETProducer.h
+++ b/Producers/interface/KPatMETProducer.h
@@ -33,7 +33,6 @@ public:
 		// fill properties of basic MET
 		KMETProducer::fillMET<pat::MET>(in, out);
 		if(uncor){
-			if (CMSSW_MAJOR_VERSION >= 7){
 			out.p4 = in.uncorP4();
 			out.sumEt = in.uncorSumEt();
 				if (verbosity > 0){

--- a/Producers/interface/KPatMETProducer.h
+++ b/Producers/interface/KPatMETProducer.h
@@ -33,8 +33,16 @@ public:
 		// fill properties of basic MET
 		KMETProducer::fillMET<pat::MET>(in, out);
 		if(uncor){
+			if (CMSSW_MAJOR_VERSION >= 7){
 			out.p4 = in.uncorP4();
 			out.sumEt = in.uncorSumEt();
+				if (verbosity > 0){
+				std::cout << "MET uncorrection enabled.";
+				}
+			}
+			else{
+			std::cout << "Warning: MET is not uncorrected! Use CMSSW 7 or higher to use this feature." << std::endl; 
+			}
 		}
 		if(in.isPFMET())
 		{

--- a/Producers/interface/KPatMETProducer.h
+++ b/Producers/interface/KPatMETProducer.h
@@ -37,7 +37,7 @@ public:
 			out.p4 = in.uncorP4();
 			out.sumEt = in.uncorSumEt();
 				if (verbosity > 0){
-				std::cout << "MET uncorrection enabled.";
+				std::cout << "MET uncorrection enabled."<< std::endl;
 				}
 			}
 			else{

--- a/Producers/interface/KPatMETProducer.h
+++ b/Producers/interface/KPatMETProducer.h
@@ -33,16 +33,15 @@ public:
 		// fill properties of basic MET
 		KMETProducer::fillMET<pat::MET>(in, out);
 		if(uncor){
-			if (CMSSW_MAJOR_VERSION >= 7){
+			#if (CMSSW_MAJOR_VERSION >= 7)
 				out.p4 = in.uncorP4();
 				out.sumEt = in.uncorSumEt();
 				if (verbosity > 0){
-					std::cout << "MET uncorrection enabled."<< std::endl;
+					std::cout << "KPatMETProducer::fillMET : MET uncorrection enabled."<< std::endl;
 				}
-			}
-			else{
-			std::cout << "Warning: MET is not uncorrected! Use CMSSW 7 or higher to use this feature." << std::endl; 
-			}
+			#else
+			std::cout << "ERROR: MET is not uncorrected! Use CMSSW 7 or higher to use this feature." << std::endl; 
+			#endif
 		}
 		if(in.isPFMET())
 		{

--- a/Producers/interface/KPatMETProducer.h
+++ b/Producers/interface/KPatMETProducer.h
@@ -35,6 +35,7 @@ public:
 		if(uncor){
 			out.p4 = in.uncorP4();
 			out.sumEt = in.uncorSumEt();
+<<<<<<< HEAD
 				if (verbosity > 0){
 				std::cout << "MET uncorrection enabled."<< std::endl;
 				}
@@ -42,6 +43,8 @@ public:
 			else{
 			std::cout << "Warning: MET is not uncorrected! Use CMSSW 7 or higher to use this feature." << std::endl; 
 			}
+=======
+>>>>>>> parent of 3629a62... Met uncorrection disabled for CMSSW<7
 		}
 		if(in.isPFMET())
 		{

--- a/Producers/interface/KPatMETProducer.h
+++ b/Producers/interface/KPatMETProducer.h
@@ -33,18 +33,16 @@ public:
 		// fill properties of basic MET
 		KMETProducer::fillMET<pat::MET>(in, out);
 		if(uncor){
-			out.p4 = in.uncorP4();
-			out.sumEt = in.uncorSumEt();
-<<<<<<< HEAD
+			if (CMSSW_MAJOR_VERSION >= 7){
+				out.p4 = in.uncorP4();
+				out.sumEt = in.uncorSumEt();
 				if (verbosity > 0){
-				std::cout << "MET uncorrection enabled."<< std::endl;
+					std::cout << "MET uncorrection enabled."<< std::endl;
 				}
 			}
 			else{
 			std::cout << "Warning: MET is not uncorrected! Use CMSSW 7 or higher to use this feature." << std::endl; 
 			}
-=======
->>>>>>> parent of 3629a62... Met uncorrection disabled for CMSSW<7
 		}
 		if(in.isPFMET())
 		{

--- a/Producers/python/KTuple_cff.py
+++ b/Producers/python/KTuple_cff.py
@@ -236,7 +236,7 @@ kappaTupleDefaultsBlock = cms.PSet(
 		manual = cms.VInputTag(),
 		whitelist = cms.vstring("slimmedMETs"),
 		blacklist = cms.vstring(),
-
+		uncorrected = cms.bool(False),
 		rename = cms.vstring("slimmedMETs => met", "patPFMet => met"),
 		rename_whitelist= cms.vstring(),
 		rename_blacklist = cms.vstring(),
@@ -245,7 +245,7 @@ kappaTupleDefaultsBlock = cms.PSet(
 		manual = cms.VInputTag(),
 		whitelist = cms.vstring("slimmedMETs"),
 		blacklist = cms.vstring(),
-
+		uncorrected = cms.bool(False),
 		rename = cms.vstring("slimmedMETs => met"),
 		rename_whitelist= cms.vstring(),
 		rename_blacklist = cms.vstring(),


### PR DESCRIPTION
I made a small change in KTuple.py and KMETProducer. This should not change anything if you don't configure the uncorrection explicitely, but I'm still new and a bit scared, so I want you to have a look at my changes.
