### PR TITLE
Tests short

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 env:
   #- TEST_CMSSW_VERSION=CMSSW_8_0_26_patch1 SCRAM_ARCH=slc6_amd64_gcc530 CHECKOUTSCRIPT=checkoutCmssw80xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
-  - TEST_CMSSW_VERSION=CMSSW_7_6_3         SCRAM_ARCH=slc6_amd64_gcc493 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=true
+  - TEST_CMSSW_VERSION=CMSSW_7_6_3 SCRAM_ARCH=slc6_amd64_gcc493 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=true
   #- TEST_CMSSW_VERSION=CMSSW_5_3_29 SCRAM_ARCH=slc6_amd64_gcc472 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
   # skim_tutorial1_basic.py - checkoutDummy.sh and checkoutTauRefit.py are not available
   #- TEST_CMSSW_VERSION=CMSSW_7_4_14 SCRAM_ARCH=slc6_amd64_gcc491 CHECKOUTSCRIPT=checkoutTauRefit.py SKIMMING_SCRIPT=Kappa/Skimming/examples/skim_tutorial1_basic.py ADDITIONAL_OUTPUT=false
@@ -39,6 +39,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 script:
   - docker run --privileged -e TEST_CMSSW_VERSION=${TEST_CMSSW_VERSION}
+                            -e SCRAM_ARCH=${SCRAM_ARCH}
                             -e CHECKOUTSCRIPT=${CHECKOUTSCRIPT}
                             -e SKIMMING_SCRIPT=${SKIMMING_SCRIPT}
                             -e ADDITIONAL_OUTPUT=${ADDITIONAL_OUTPUT}

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
   - echo $HOME
   - sudo curl -o $HOME/short_rootfiles.tar https://cernbox.cern.ch/index.php/s/WeawecKp2BD2BH2/download
   - echo $HOME
+  - ls $HOME
   - sudo tar -xvf $HOME/short_rootfiles.tar -C /home/
   - sudo ls /home/short
   - "export DISPLAY=:99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
                             -e ADDITIONAL_OUTPUT=${ADDITIONAL_OUTPUT}
                             -v ${TRAVIS_BUILD_DIR}:/home/travis 
                             -v '/home/short:/home/short' claria/cvmfs-cms /bin/bash 
-                            -c "cd /home/; /home/travis/test_build.sh"
+                            -c "cd /home/; source /home/travis/test_build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
                             -e ADDITIONAL_OUTPUT=${ADDITIONAL_OUTPUT}
                             -v ${TRAVIS_BUILD_DIR}:/home/travis
                             -v '/home/short:/home/short' claria/cvmfs-cms /bin/bash 
-                            -c "cd /home/; source /home/travis/test_build.sh"
+                            -c "cd /home/; source /home/travis/test_build.sh -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ script:
                             -e CHECKOUTSCRIPT=${CHECKOUTSCRIPT}
                             -e SKIMMING_SCRIPT=${SKIMMING_SCRIPT}
                             -e ADDITIONAL_OUTPUT=${ADDITIONAL_OUTPUT}
-                            -v ${TRAVIS_BUILD_DIR}:/home/travis 
+                            -v ${TRAVIS_BUILD_DIR}:/home/travis
                             -v '/home/short:/home/short' claria/cvmfs-cms /bin/bash 
                             -c "cd /home/; source /home/travis/test_build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ before_script:
   - sleep 3 # give xvfb some time to start
 script:
   - docker run --privileged -e TEST_CMSSW_VERSION=${TEST_CMSSW_VERSION}
-                            -e SCRAM_ARCH=${SCRAM_ARCH}
                             -e CHECKOUTSCRIPT=${CHECKOUTSCRIPT}
                             -e SKIMMING_SCRIPT=${SKIMMING_SCRIPT}
                             -e ADDITIONAL_OUTPUT=${ADDITIONAL_OUTPUT}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 env:
   #- TEST_CMSSW_VERSION=CMSSW_8_0_26_patch1 SCRAM_ARCH=slc6_amd64_gcc530 CHECKOUTSCRIPT=checkoutCmssw80xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
-  - TEST_CMSSW_VERSION=CMSSW_7_6_3         SCRAM_ARCH=slc6_amd64_gcc493 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
+  - TEST_CMSSW_VERSION=CMSSW_7_6_3         SCRAM_ARCH=slc6_amd64_gcc493 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=true
   #- TEST_CMSSW_VERSION=CMSSW_5_3_29 SCRAM_ARCH=slc6_amd64_gcc472 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
   # skim_tutorial1_basic.py - checkoutDummy.sh and checkoutTauRefit.py are not available
   #- TEST_CMSSW_VERSION=CMSSW_7_4_14 SCRAM_ARCH=slc6_amd64_gcc491 CHECKOUTSCRIPT=checkoutTauRefit.py SKIMMING_SCRIPT=Kappa/Skimming/examples/skim_tutorial1_basic.py ADDITIONAL_OUTPUT=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 env:
   #- TEST_CMSSW_VERSION=CMSSW_8_0_26_patch1 SCRAM_ARCH=slc6_amd64_gcc530 CHECKOUTSCRIPT=checkoutCmssw80xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
-  - TEST_CMSSW_VERSION=CMSSW_7_6_3         SCRAM_ARCH=slc6_amd64_gcc493 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=true
+  - TEST_CMSSW_VERSION=CMSSW_7_6_3         SCRAM_ARCH=slc6_amd64_gcc493 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
   #- TEST_CMSSW_VERSION=CMSSW_5_3_29 SCRAM_ARCH=slc6_amd64_gcc472 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
   # skim_tutorial1_basic.py - checkoutDummy.sh and checkoutTauRefit.py are not available
   #- TEST_CMSSW_VERSION=CMSSW_7_4_14 SCRAM_ARCH=slc6_amd64_gcc491 CHECKOUTSCRIPT=checkoutTauRefit.py SKIMMING_SCRIPT=Kappa/Skimming/examples/skim_tutorial1_basic.py ADDITIONAL_OUTPUT=false

--- a/Skimming/scripts/checkoutCmssw53xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw53xPackagesForSkimming.sh
@@ -9,6 +9,28 @@ scramv1 project CMSSW CMSSW_5_3_35
 cd CMSSW_5_3_35/src
 eval `scramv1 runtime -sh`
 
+# Re-configure git if needed
+set +e
+git_github="$(git config --global --get-all user.github)"
+git_email="$(git config --global --get-all user.email)"
+git_name="$(git config --global --get-all user.name)" 
+echo "git config before:" $git_github $git_email $git_name
+
+while getopts :g:e:n: option
+do
+	case "${option}"
+	in
+	g) git config --global user.github ${OPTARG};;
+	e) git config --global user.email ${OPTARG};;
+	n) git config --global user.name "\"${OPTARG}\"";;
+	esac
+done
+
+git_github=`git config --get user.github`
+git_email=`git config --get user.email`
+git_name=`git config --get-all user.name`
+echo "git config after:" $git_github $git_email $git_name
+set -e
 
 cd $CMSSW_BASE/src
 # do the git cms-addpkg before starting with checking out cvs repositories
@@ -59,4 +81,7 @@ cp Kappa/Skimming/higgsTauTau/kappa_sl6_fix/myJetAna.cc  RecoJets/JetAnalyzers/s
 # fixes for classes
 cp Kappa/Skimming/higgsTauTau/kappa_fixmissing_class/classes_def.xml Kappa/DataFormats/src/classes_def.xml
 
-scram b -j 4
+scram b -j 4 -v || {
+      echo "The ${CMSSW_BASE} with Kappa could not be built"
+      exit 1
+}

--- a/Skimming/scripts/checkoutCmssw53xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw53xPackagesForSkimming.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-echo "what is \$0: $0"
+#!/bin/sh
 set -e # exit on errors
 
 echo "set param"

--- a/Skimming/scripts/checkoutCmssw53xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw53xPackagesForSkimming.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
+echo "what is \$0: $0"
 set -e # exit on errors
 
+echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc491
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-source $VO_CMS_SW_DIR/cmsset_default.sh
+. $VO_CMS_SW_DIR/cmsset_default.sh
 
+echo "Set CMSSW"
 scramv1 project CMSSW CMSSW_5_3_35
 cd CMSSW_5_3_35/src
 eval `scramv1 runtime -sh`
+echo "CMSSW setting is done"
 
 # Re-configure git if needed
 set +e
+echo "set git config"
 git_github="$(git config --global --get-all user.github)"
 git_email="$(git config --global --get-all user.email)"
 git_name="$(git config --global --get-all user.name)" 

--- a/Skimming/scripts/checkoutCmssw7414PackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw7414PackagesForSkimming.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-echo "what is \$0: $0"
+#!/bin/sh
 set -e # exit on errors
 
 echo "set param"

--- a/Skimming/scripts/checkoutCmssw7414PackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw7414PackagesForSkimming.sh
@@ -9,6 +9,28 @@ scramv1 project CMSSW_7_4_1_patch4;
 cd CMSSW_7_4_1_patch4/src
 eval `scramv1 runtime -sh`
 
+# Re-configure git if needed
+set +e
+git_github="$(git config --global --get-all user.github)"
+git_email="$(git config --global --get-all user.email)"
+git_name="$(git config --global --get-all user.name)" 
+echo "git config before:" $git_github $git_email $git_name
+
+while getopts :g:e:n: option
+do
+	case "${option}"
+	in
+	g) git config --global user.github ${OPTARG};;
+	e) git config --global user.email ${OPTARG};;
+	n) git config --global user.name "\"${OPTARG}\"";;
+	esac
+done
+
+git_github=`git config --get user.github`
+git_email=`git config --get user.email`
+git_name=`git config --get-all user.name`
+echo "git config after:" $git_github $git_email $git_name
+set -e
 
 cd $CMSSW_BASE/src
 # do the git cms-addpkg before starting with checking out cvs repositories
@@ -45,4 +67,8 @@ git cms-merge-topic ikrav:egm_id_7.4.12_v1
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 
-scram b -j 4
+scram b -j 4 -v || {
+      echo "The ${CMSSW_BASE} with Kappa could not be built"
+      exit 1
+}
+

--- a/Skimming/scripts/checkoutCmssw7414PackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw7414PackagesForSkimming.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
+echo "what is \$0: $0"
 set -e # exit on errors
 
+echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc491
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-source $VO_CMS_SW_DIR/cmsset_default.sh
+. $VO_CMS_SW_DIR/cmsset_default.sh
 
+echo "Set CMSSW"
 scramv1 project CMSSW_7_4_1_patch4;
 cd CMSSW_7_4_1_patch4/src
 eval `scramv1 runtime -sh`
+echo "CMSSW setting is done"
 
 # Re-configure git if needed
 set +e
+echo "set git config"
 git_github="$(git config --global --get-all user.github)"
 git_email="$(git config --global --get-all user.email)"
 git_name="$(git config --global --get-all user.name)" 
@@ -71,4 +76,3 @@ scram b -j 4 -v || {
       echo "The ${CMSSW_BASE} with Kappa could not be built"
       exit 1
 }
-

--- a/Skimming/scripts/checkoutCmssw74xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw74xPackagesForSkimming.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
+echo "what is \$0: $0"
 set -e # exit on errors
 
+echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc491
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-source $VO_CMS_SW_DIR/cmsset_default.sh
+. $VO_CMS_SW_DIR/cmsset_default.sh
 
+echo "Set CMSSW"
 scramv1 project CMSSW CMSSW_7_4_16_patch2;
 cd CMSSW_7_4_16_patch2/src
 eval `scramv1 runtime -sh`
+echo "CMSSW setting is done"
 
 # Re-configure git if needed
 set +e
+echo "set git config"
 git_github="$(git config --global --get-all user.github)"
 git_email="$(git config --global --get-all user.email)"
 git_name="$(git config --global --get-all user.name)" 

--- a/Skimming/scripts/checkoutCmssw74xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw74xPackagesForSkimming.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-echo "what is \$0: $0"
+#!/bin/sh
 set -e # exit on errors
 
 echo "set param"

--- a/Skimming/scripts/checkoutCmssw74xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw74xPackagesForSkimming.sh
@@ -9,6 +9,28 @@ scramv1 project CMSSW CMSSW_7_4_16_patch2;
 cd CMSSW_7_4_16_patch2/src
 eval `scramv1 runtime -sh`
 
+# Re-configure git if needed
+set +e
+git_github="$(git config --global --get-all user.github)"
+git_email="$(git config --global --get-all user.email)"
+git_name="$(git config --global --get-all user.name)" 
+echo "git config before:" $git_github $git_email $git_name
+
+while getopts :g:e:n: option
+do
+	case "${option}"
+	in
+	g) git config --global user.github ${OPTARG};;
+	e) git config --global user.email ${OPTARG};;
+	n) git config --global user.name "\"${OPTARG}\"";;
+	esac
+done
+
+git_github=`git config --get user.github`
+git_email=`git config --get user.email`
+git_name=`git config --get-all user.name`
+echo "git config after:" $git_github $git_email $git_name
+set -e
 
 cd $CMSSW_BASE/src
 # do the git cms-addpkg before starting with checking out cvs repositories
@@ -44,4 +66,7 @@ git cms-merge-topic ikrav:egm_id_747_v2
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 
-scram b -j 4
+scram b -j 4 -v || {
+      echo "The ${CMSSW_BASE} with Kappa could not be built"
+      exit 1
+}

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -11,7 +11,7 @@ type scramv1
 type scram
 
 echo "set cmssw"
-scramv1 project CMSSW CMSSW_7_6_3
+eval `scramv1 project CMSSW CMSSW_7_6_3`
 cd CMSSW_7_6_3/src
 eval `scramv1 runtime -sh`
 echo "cmssw setting is done"

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "what is 0: $0"
 set -e # exit on errors
 
 echo "set param"

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -22,5 +22,8 @@ git clone https://github.com/artus-analysis/TauRefit.git VertexRefit/TauRefit
 
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
-
+echo "PWD:"
+pwd
+echo "ls:"
+ls
 #scram b -j 4

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-echo "what is \$0: $0"
+#!/bin/sh
 set -e # exit on errors
 
 echo "set param"

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -e # exit on errors
 
+echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc493
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 source $VO_CMS_SW_DIR/cmsset_default.sh
 
+echo "set cmssw"
 scramv1 project CMSSW CMSSW_7_6_3
 cd CMSSW_7_6_3/src
 eval `scramv1 runtime -sh`
 
 # Re-configure git if needed
 set +e
+echo "set git config"
 git_github="$(git config --global --get-all user.github)"
 git_email="$(git config --global --get-all user.email)"
 git_name="$(git config --global --get-all user.name)" 

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
-set -e # exit on errors
+#set -e # exit on errors
 
 echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc493
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 source $VO_CMS_SW_DIR/cmsset_default.sh
 
+type scramv1
+type scram
+type cmsenv
+
 echo "set cmssw"
 scramv1 project CMSSW CMSSW_7_6_3
 cd CMSSW_7_6_3/src
-#eval `scramv1 runtime -sh`
-cmsenv
+eval `scramv1 runtime -sh`
 
 echo "Checking system variables"
 echo "PYTHONSTARTUP=$PYTHONSTARTUP"

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 echo "what is 0: $0"
 set -e # exit on errors
 

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -67,4 +67,5 @@ git clone https://github.com/KappaAnalysis/Kappa.git
 #       echo "The ${CMSSW_BASE} with Kappa could not be built"
 #       exit 1
 # }
-
+cd $CMSSW_BASE/src
+echo "pwd:" && pwd

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -23,4 +23,4 @@ git clone https://github.com/artus-analysis/TauRefit.git VertexRefit/TauRefit
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 
-scram b -j 4
+#scram b -j 4

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -11,6 +11,16 @@ scramv1 project CMSSW CMSSW_7_6_3
 cd CMSSW_7_6_3/src
 eval `scramv1 runtime -sh`
 
+echo "Checking system variables"
+echo "PYTHONSTARTUP=$PYTHONSTARTUP"
+echo "PYTHONPATH=$PYTHONPATH"
+echo "SCRAM_ARCH=$SCRAM_ARCH"
+echo "VO_CMS_SW_DIR=$VO_CMS_SW_DIR"
+echo "CMSSW_VERSION=$CMSSW_VERSION"
+echo "CMSSW_GIT_HASH=$CMSSW_GIT_HASH"
+echo "CMSSW_BASE=$CMSSW_BASE"
+echo "CMSSW_RELEASE_BASE=$CMSSW_RELEASE_BASE"
+
 # Re-configure git if needed
 set +e
 echo "set git config"

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -4,7 +4,7 @@ set -e # exit on errors
 echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc493
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-source $VO_CMS_SW_DIR/cmsset_default.sh
+. ./$VO_CMS_SW_DIR/cmsset_default.sh
 
 type scramv1
 type scram

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-echo "what is 0: $0"
+#!/bin/bash
+echo "what is \$0: $0"
 set -e # exit on errors
 
 echo "set param"
@@ -7,24 +7,11 @@ export SCRAM_ARCH=slc6_amd64_gcc493
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 . $VO_CMS_SW_DIR/cmsset_default.sh
 
-type scramv1
-type scram
-
-echo "set cmssw"
-eval `scramv1 project CMSSW CMSSW_7_6_3`
+echo "Set CMSSW"
+scramv1 project CMSSW CMSSW_7_6_3
 cd CMSSW_7_6_3/src
 eval `scramv1 runtime -sh`
-echo "cmssw setting is done"
-
-echo "Checking system variables"
-echo "PYTHONSTARTUP=$PYTHONSTARTUP"
-echo "PYTHONPATH=$PYTHONPATH"
-echo "SCRAM_ARCH=$SCRAM_ARCH"
-echo "VO_CMS_SW_DIR=$VO_CMS_SW_DIR"
-echo "CMSSW_VERSION=$CMSSW_VERSION"
-echo "CMSSW_GIT_HASH=$CMSSW_GIT_HASH"
-echo "CMSSW_BASE=$CMSSW_BASE"
-echo "CMSSW_RELEASE_BASE=$CMSSW_RELEASE_BASE"
+echo "CMSSW setting is done"
 
 # Re-configure git if needed
 set +e
@@ -63,9 +50,7 @@ git clone https://github.com/artus-analysis/TauRefit.git VertexRefit/TauRefit
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 
-# scram b -j 4 -v || {
-#       echo "The ${CMSSW_BASE} with Kappa could not be built"
-#       exit 1
-# }
-cd $CMSSW_BASE/src
-echo "pwd:" && pwd
+scram b -j 4 -v || {
+      echo "The ${CMSSW_BASE} with Kappa could not be built"
+      exit 1
+}

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -9,7 +9,8 @@ source $VO_CMS_SW_DIR/cmsset_default.sh
 echo "set cmssw"
 scramv1 project CMSSW CMSSW_7_6_3
 cd CMSSW_7_6_3/src
-eval `scramv1 runtime -sh`
+#eval `scramv1 runtime -sh`
+cmsenv
 
 echo "Checking system variables"
 echo "PYTHONSTARTUP=$PYTHONSTARTUP"

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -5,7 +5,7 @@ set -e # exit on errors
 echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc493
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-. ./$VO_CMS_SW_DIR/cmsset_default.sh
+. $VO_CMS_SW_DIR/cmsset_default.sh
 
 type scramv1
 type scram

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -9,6 +9,28 @@ scramv1 project CMSSW CMSSW_7_6_3
 cd CMSSW_7_6_3/src
 eval `scramv1 runtime -sh`
 
+# Re-configure git if needed
+set +e
+git_github="$(git config --global --get-all user.github)"
+git_email="$(git config --global --get-all user.email)"
+git_name="$(git config --global --get-all user.name)" 
+echo "git config before:" $git_github $git_email $git_name
+
+while getopts :g:e:n: option
+do
+	case "${option}"
+	in
+	g) git config --global user.github ${OPTARG};;
+	e) git config --global user.email ${OPTARG};;
+	n) git config --global user.name "\"${OPTARG}\"";;
+	esac
+done
+
+git_github=`git config --get user.github`
+git_email=`git config --get user.email`
+git_name=`git config --get-all user.name`
+echo "git config after:" $git_github $git_email $git_name
+set -e
 
 cd $CMSSW_BASE/src
 git cms-merge-topic -u KappaAnalysis:Kappa_CMSSW_763
@@ -22,8 +44,9 @@ git clone https://github.com/artus-analysis/TauRefit.git VertexRefit/TauRefit
 
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
-echo "PWD:"
-pwd
-echo "ls:"
-ls
-#scram b -j 4
+
+scram b -j 4 -v || {
+      echo "The ${CMSSW_BASE} with Kappa could not be built"
+      exit 1
+}
+

--- a/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw76xPackagesForSkimming.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -e # exit on errors
+set -e # exit on errors
 
 echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc493
@@ -8,12 +8,12 @@ source $VO_CMS_SW_DIR/cmsset_default.sh
 
 type scramv1
 type scram
-type cmsenv
 
 echo "set cmssw"
 scramv1 project CMSSW CMSSW_7_6_3
 cd CMSSW_7_6_3/src
 eval `scramv1 runtime -sh`
+echo "cmssw setting is done"
 
 echo "Checking system variables"
 echo "PYTHONSTARTUP=$PYTHONSTARTUP"
@@ -62,8 +62,8 @@ git clone https://github.com/artus-analysis/TauRefit.git VertexRefit/TauRefit
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 
-scram b -j 4 -v || {
-      echo "The ${CMSSW_BASE} with Kappa could not be built"
-      exit 1
-}
+# scram b -j 4 -v || {
+#       echo "The ${CMSSW_BASE} with Kappa could not be built"
+#       exit 1
+# }
 

--- a/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
@@ -9,6 +9,28 @@ scramv1 project CMSSW CMSSW_8_0_26_patch1
 cd CMSSW_8_0_26_patch1/src
 eval `scramv1 runtime -sh`
 
+# Re-configure git if needed
+set +e
+git_github="$(git config --global --get-all user.github)"
+git_email="$(git config --global --get-all user.email)"
+git_name="$(git config --global --get-all user.name)" 
+echo "git config before:" $git_github $git_email $git_name
+
+while getopts :g:e:n: option
+do
+	case "${option}"
+	in
+	g) git config --global user.github ${OPTARG};;
+	e) git config --global user.email ${OPTARG};;
+	n) git config --global user.name "\"${OPTARG}\"";;
+	esac
+done
+
+git_github=`git config --get user.github`
+git_email=`git config --get user.email`
+git_name=`git config --get-all user.name`
+echo "git config after:" $git_github $git_email $git_name
+set -e
 
 cd $CMSSW_BASE/src
 #Electron cutBased Id and MVA Id
@@ -55,4 +77,7 @@ rm -rf RecoEgamma/ElectronIdentification/data/.git
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 
-scram b -j 4
+scram b -j 4 -v || {
+      echo "The ${CMSSW_BASE} with Kappa could not be built"
+      exit 1
+}

--- a/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-echo "what is \$0: $0"
+#!/bin/sh
 set -e # exit on errors
 
 echo "set param"

--- a/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
+echo "what is \$0: $0"
 set -e # exit on errors
 
+echo "set param"
 export SCRAM_ARCH=slc6_amd64_gcc530
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-source $VO_CMS_SW_DIR/cmsset_default.sh
+. $VO_CMS_SW_DIR/cmsset_default.sh
 
+echo "Set CMSSW"
 scramv1 project CMSSW CMSSW_8_0_26_patch1
 cd CMSSW_8_0_26_patch1/src
 eval `scramv1 runtime -sh`
+echo "CMSSW setting is done"
 
 # Re-configure git if needed
 set +e
+echo "set git config"
 git_github="$(git config --global --get-all user.github)"
 git_email="$(git config --global --get-all user.email)"
 git_name="$(git config --global --get-all user.name)" 

--- a/test_build.sh
+++ b/test_build.sh
@@ -173,7 +173,7 @@ echo "# ================= #"
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
-    exec bash
+    set -x
     printf "no\n" | . ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 echo $0
 echo "# ================= #"
 echo "# Checking wget "

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 echo "what is 0: $0"
 echo "# ================= #"
 echo "# Checking wget "

--- a/test_build.sh
+++ b/test_build.sh
@@ -116,6 +116,7 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo
 fi
 
+    echo "which git:" && which git
 
 # export SCRAM_ARCH=slc6_amd64_gcc481
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
@@ -150,6 +151,7 @@ echo
     git config --global user.github greyxray
     git config --global user.email 'greyxray@gmail.com'
     git config --global user.name 'kappa test'
+    echo "which git:" && which git
 exit 1
 
 echo "# ================= #"

--- a/test_build.sh
+++ b/test_build.sh
@@ -181,6 +181,8 @@ echo "# ================= #"
     echo "sourced"
     echo "pwd:" && pwd
     source $VO_CMS_SW_DIR/cmsset_default.sh;
+    echo "cd TEST_CMSSW_VERSION"
+    cd $TEST_CMSSW_VERSION/src
     eval `scramv1 runtime -sh`
 
     echo "Checking system variables"

--- a/test_build.sh
+++ b/test_build.sh
@@ -169,7 +169,7 @@ echo "# ================= #"
 echo "# Download checkout script for Kappa"
 echo "# ================= #"
     mkdir -p /home/build && cd /home/build
-    curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}
+    curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/master/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
     set -x
@@ -187,7 +187,11 @@ echo "# ================= #"
     echo "cd TEST_CMSSW_VERSION"
     cd $TEST_CMSSW_VERSION/src
     eval `scramv1 runtime -sh`
-    cd $CMSSW_BASE
+    cd $CMSSW_BASE/src
+    scram b -j 4 -v || {
+      echo "The ${CMSSW_BASE} with Kappa could not be built"
+      exit 1
+}
 echo "# ================= #"
 echo
 

--- a/test_build.sh
+++ b/test_build.sh
@@ -187,7 +187,7 @@ echo "# Download checkout script for Kappa"
 echo "# ================= #"
     #mkdir Kappa
     #cp -r /home/travis/* Kappa/
-    cd ../../
+    cd /home/build
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/master/Skimming/scripts/${CHECKOUTSCRIPT}
     git config --global user.github greyxray
     git config --global user.email 'greyxray@gmail.com'

--- a/test_build.sh
+++ b/test_build.sh
@@ -192,6 +192,10 @@ echo "# ================= #"
     git config --global user.github greyxray
     git config --global user.email 'greyxray@gmail.com'
     git config --global user.name 'kappa test'
+    echo "ls:"
+    ls
+    echo "pwd:"
+    pwd
     printf "no\n" | source ${CHECKOUTSCRIPT} || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -170,7 +170,7 @@ echo "# ================= #"
 echo "# Download checkout script for Kappa"
 echo "# ================= #"
     mkdir -p /home/build && cd /home/build
-    curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/master/Skimming/scripts/${CHECKOUTSCRIPT}
+    curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
     printf "no\n" | ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 echo "what is 0: $0"
 echo "# ================= #"
 echo "# Checking wget "
@@ -119,7 +119,6 @@ fi
 
 # export SCRAM_ARCH=slc6_amd64_gcc481
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-
 if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo "# ================= #"
     echo "# cmsset_default.sh"
@@ -178,22 +177,16 @@ echo "# ================= #"
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1
     }
-    echo "sourced"
-    echo "pwd:" && pwd
+echo "# ================= #"
+echo
+
+echo "# ================= #"
+echo "# Set CMSSW variables"
+echo "# ================= #"
     source $VO_CMS_SW_DIR/cmsset_default.sh;
     echo "cd TEST_CMSSW_VERSION"
     cd $TEST_CMSSW_VERSION/src
     eval `scramv1 runtime -sh`
-
-    echo "Checking system variables"
-    echo "PYTHONSTARTUP=$PYTHONSTARTUP"
-    echo "PYTHONPATH=$PYTHONPATH"
-    echo "SCRAM_ARCH=$SCRAM_ARCH"
-    echo "VO_CMS_SW_DIR=$VO_CMS_SW_DIR"
-    echo "CMSSW_VERSION=$CMSSW_VERSION"
-    echo "CMSSW_GIT_HASH=$CMSSW_GIT_HASH"
-    echo "CMSSW_BASE=$CMSSW_BASE"
-    echo "CMSSW_RELEASE_BASE=$CMSSW_RELEASE_BASE"
     cd $CMSSW_BASE
 echo "# ================= #"
 echo
@@ -226,8 +219,8 @@ echo "# =================== #"
 echo "# Cat the Config #"
 echo "# =================== #"
     cat $CMSSW_BASE/src/$SKIMMING_SCRIPT || {
-    echo "The ${CMSSW_BASE}/src/${SKIMMING_SCRIPT} could not be read"
-    exit 1
+        echo "The ${CMSSW_BASE}/src/${SKIMMING_SCRIPT} could not be read"
+        exit 1
     }
     #Kappa/Skimming/examples/travis/skim_tutorial1_basic.py
 echo "# ================= #"
@@ -236,7 +229,7 @@ echo
 echo "# =================== #"
 echo "# Test python #"
 echo "# =================== #"
-    cd src/Kappa && mkdir kappa_run && cd kappa_run
+    cd $CMSSW_BASE/src/Kappa && mkdir kappa_run && cd kappa_run
     python $CMSSW_BASE/src/$SKIMMING_SCRIPT || {
         echo "Possible python syntax error "
         #exit 5

--- a/test_build.sh
+++ b/test_build.sh
@@ -174,10 +174,6 @@ echo "# ================= #"
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
     set -x
-    source ./${CHECKOUTSCRIPT}
-echo "# ================= #"
-echo "# basic attempt to checkout script for Kappa"
-echo "# ================= #"
     printf "no\n" | . ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -205,10 +205,10 @@ echo
 echo "# ================= #"
 echo "# Building in CMSSW_BASE #"
 echo "# ================= #"
-    scram b -v -j 2 || {
-        echo "The ${CMSSW_BASE} with Kappa could not be built"
-        exit 1
-    }
+    #scram b -v -j 2 || {
+    #    echo "The ${CMSSW_BASE} with Kappa could not be built"
+    #    exit 1
+    #}
 echo "# ================= #"
 echo
 
@@ -235,6 +235,13 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo "# ================= #"
     echo
 fi
+
+echo"PWD:"
+pwd
+echo "LS:"
+ls
+echo "LS:SRC"
+ls src
 
 cd src/Kappa
 mkdir kappa_run

--- a/test_build.sh
+++ b/test_build.sh
@@ -196,7 +196,9 @@ echo "# ================= #"
     ls
     echo "pwd:"
     pwd
-    . ${CHECKOUTSCRIPT}
+    cat ${CHECKOUTSCRIPT}
+    chmod +x  ${CHECKOUTSCRIPT}
+    ./${CHECKOUTSCRIPT}  
     printf "no\n" | source ${CHECKOUTSCRIPT} || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -116,11 +116,9 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo
 fi
 
-    echo "which git:" && which git
 
 # export SCRAM_ARCH=slc6_amd64_gcc481
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-mkdir -p /home/build && cd /home/build
 
 if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo "# ================= #"
@@ -133,30 +131,6 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     cat /proc/cpuinfo | awk '/^processor/{print $3}'
     echo
 fi
-
-echo "# ================= #"
-    . $VO_CMS_SW_DIR/cmsset_default.sh
-echo "# ================= #"
-echo
-    git config --global user.github greyxray
-    git config --global user.email 'greyxray@gmail.com'
-    git config --global user.name 'kappa test'
-    echo "which git:" && which git
-
-echo "# ================= #"
-echo "# Compiling CMSSW"
-echo "# ================= #"
-    scram project ${TEST_CMSSW_VERSION}
-    cd ${TEST_CMSSW_VERSION}
-    cmsenv
-echo "# ================= #"
-echo
-
-    git config --global user.github greyxray
-    git config --global user.email 'greyxray@gmail.com'
-    git config --global user.name 'kappa test'
-    echo "which git:" && which git
-exit 1
 
 echo "# ================= #"
 echo "# curl -O root files"
@@ -195,30 +169,15 @@ echo
 echo "# ================= #"
 echo "# Download checkout script for Kappa"
 echo "# ================= #"
-    #mkdir Kappa
-    #cp -r /home/travis/* Kappa/
-    cd /home/build
+    mkdir -p /home/build && cd /home/build
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/master/Skimming/scripts/${CHECKOUTSCRIPT}
-    git config --global user.github greyxray
-    git config --global user.email 'greyxray@gmail.com'
-    git config --global user.name 'kappa test'
-    chmod +x  ${CHECKOUTSCRIPT}
-    printf "no\n" | ./${CHECKOUTSCRIPT} || {
+    chmod +x ${CHECKOUTSCRIPT}
+    printf "no\n" | ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1
     }
     echo
     cd $CMSSW_BASE
-echo "# ================= #"
-echo
-
-echo "# ================= #"
-echo "# Building in CMSSW_BASE #"
-echo "# ================= #"
-    #scram b -v -j 2 || {
-    #    echo "The ${CMSSW_BASE} with Kappa could not be built"
-    #    exit 1
-    #}
 echo "# ================= #"
 echo
 
@@ -246,17 +205,6 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo
 fi
 
-echo "PWD:"
-pwd
-echo "LS:"
-ls
-echo "LS:SRC"
-ls src
-
-cd src/Kappa
-mkdir kappa_run
-cd kappa_run
-    
 echo "# =================== #"
 echo "# Cat the Config #"
 echo "# =================== #"
@@ -271,6 +219,7 @@ echo
 echo "# =================== #"
 echo "# Test python #"
 echo "# =================== #"
+    cd src/Kappa && mkdir kappa_run && cd kappa_run
     python $CMSSW_BASE/src/$SKIMMING_SCRIPT || {
         echo "Possible python syntax error "
         #exit 5

--- a/test_build.sh
+++ b/test_build.sh
@@ -116,9 +116,6 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo
 fi
 
-    git config --global user.github greyxray
-    git config --global user.email 'greyxray@gmail.com'
-    git config --global user.name 'kappa test'
 
 # export SCRAM_ARCH=slc6_amd64_gcc481
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
@@ -150,6 +147,10 @@ echo "# ================= #"
 echo "# ================= #"
 echo
 
+    git config --global user.github greyxray
+    git config --global user.email 'greyxray@gmail.com'
+    git config --global user.name 'kappa test'
+exit 1
 
 echo "# ================= #"
 echo "# curl -O root files"

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+echo $0
 echo "# ================= #"
 echo "# Checking wget "
 echo "# ================= #"
@@ -173,7 +173,7 @@ echo "# ================= #"
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
-    printf "no\n" | source ${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
+    printf "no\n" | source ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1
     }

--- a/test_build.sh
+++ b/test_build.sh
@@ -179,7 +179,9 @@ echo "# ================= #"
         exit 1
     }
     echo "sourced"
-    cd $CMSSW_BASE
+    source $VO_CMS_SW_DIR/cmsset_default.sh;
+    eval `scramv1 runtime -sh`
+
     echo "Checking system variables"
     echo "PYTHONSTARTUP=$PYTHONSTARTUP"
     echo "PYTHONPATH=$PYTHONPATH"
@@ -189,6 +191,7 @@ echo "# ================= #"
     echo "CMSSW_GIT_HASH=$CMSSW_GIT_HASH"
     echo "CMSSW_BASE=$CMSSW_BASE"
     echo "CMSSW_RELEASE_BASE=$CMSSW_RELEASE_BASE"
+    cd $CMSSW_BASE
 echo "# ================= #"
 echo
 

--- a/test_build.sh
+++ b/test_build.sh
@@ -142,7 +142,7 @@ echo
     git config --global user.email 'greyxray@gmail.com'
     git config --global user.name 'kappa test'
     echo "which git:" && which git
-exit 1
+
 echo "# ================= #"
 echo "# Compiling CMSSW"
 echo "# ================= #"

--- a/test_build.sh
+++ b/test_build.sh
@@ -173,11 +173,11 @@ echo "# ================= #"
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
-    printf "no\n" | ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
+    printf "no\n" | source ${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1
     }
-    echo
+    echo "sourced"
     cd $CMSSW_BASE
     echo "Checking system variables"
     echo "PYTHONSTARTUP=$PYTHONSTARTUP"

--- a/test_build.sh
+++ b/test_build.sh
@@ -196,6 +196,7 @@ echo "# ================= #"
     ls
     echo "pwd:"
     pwd
+    sudo -s
     printf "no\n" | source ${CHECKOUTSCRIPT} || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -192,14 +192,8 @@ echo "# ================= #"
     git config --global user.github greyxray
     git config --global user.email 'greyxray@gmail.com'
     git config --global user.name 'kappa test'
-    echo "ls:"
-    ls
-    echo "pwd:"
-    pwd
-    cat ${CHECKOUTSCRIPT}
     chmod +x  ${CHECKOUTSCRIPT}
-    ./${CHECKOUTSCRIPT}  
-    printf "no\n" | source ${CHECKOUTSCRIPT} || {
+    printf "no\n" | ./${CHECKOUTSCRIPT} || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1
     }

--- a/test_build.sh
+++ b/test_build.sh
@@ -116,6 +116,9 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo
 fi
 
+    git config --global user.github greyxray
+    git config --global user.email 'greyxray@gmail.com'
+    git config --global user.name 'kappa test'
 
 # export SCRAM_ARCH=slc6_amd64_gcc481
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch

--- a/test_build.sh
+++ b/test_build.sh
@@ -173,6 +173,7 @@ echo "# ================= #"
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
+    exec bash
     printf "no\n" | . ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -179,6 +179,15 @@ echo "# ================= #"
     }
     echo
     cd $CMSSW_BASE
+    echo "Checking system variables"
+    echo "PYTHONSTARTUP=$PYTHONSTARTUP"
+    echo "PYTHONPATH=$PYTHONPATH"
+    echo "SCRAM_ARCH=$SCRAM_ARCH"
+    echo "VO_CMS_SW_DIR=$VO_CMS_SW_DIR"
+    echo "CMSSW_VERSION=$CMSSW_VERSION"
+    echo "CMSSW_GIT_HASH=$CMSSW_GIT_HASH"
+    echo "CMSSW_BASE=$CMSSW_BASE"
+    echo "CMSSW_RELEASE_BASE=$CMSSW_RELEASE_BASE"
 echo "# ================= #"
 echo
 

--- a/test_build.sh
+++ b/test_build.sh
@@ -236,7 +236,7 @@ if [ "$ADDITIONAL_OUTPUT" = true ]; then
     echo
 fi
 
-echo"PWD:"
+echo "PWD:"
 pwd
 echo "LS:"
 ls

--- a/test_build.sh
+++ b/test_build.sh
@@ -172,6 +172,7 @@ echo "# ================= #"
     mkdir -p /home/build && cd /home/build
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/master/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
+    cat ${CHECKOUTSCRIPT}
     printf "no\n" | ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -138,7 +138,11 @@ echo "# ================= #"
     . $VO_CMS_SW_DIR/cmsset_default.sh
 echo "# ================= #"
 echo
-
+    git config --global user.github greyxray
+    git config --global user.email 'greyxray@gmail.com'
+    git config --global user.name 'kappa test'
+    echo "which git:" && which git
+exit 1
 echo "# ================= #"
 echo "# Compiling CMSSW"
 echo "# ================= #"

--- a/test_build.sh
+++ b/test_build.sh
@@ -174,6 +174,10 @@ echo "# ================= #"
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
     set -x
+    source ./${CHECKOUTSCRIPT}
+echo "# ================= #"
+echo "# basic attempt to checkout script for Kappa"
+echo "# ================= #"
     printf "no\n" | . ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -173,7 +173,7 @@ echo "# ================= #"
     curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
-    printf "no\n" | source ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
+    printf "no\n" | . ./${CHECKOUTSCRIPT} -g 'greyxray' -e 'greyxray@gmail.com' -n 'kappa test' || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1
     }

--- a/test_build.sh
+++ b/test_build.sh
@@ -179,6 +179,7 @@ echo "# ================= #"
         exit 1
     }
     echo "sourced"
+    echo "pwd:" && pwd
     source $VO_CMS_SW_DIR/cmsset_default.sh;
     eval `scramv1 runtime -sh`
 

--- a/test_build.sh
+++ b/test_build.sh
@@ -196,7 +196,7 @@ echo "# ================= #"
     ls
     echo "pwd:"
     pwd
-    sudo -s
+    . ${CHECKOUTSCRIPT}
     printf "no\n" | source ${CHECKOUTSCRIPT} || {
         echo "The ${CHECKOUTSCRIPT} could not be executed"
         exit 1

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo $0
+echo "what is 0: $0"
 echo "# ================= #"
 echo "# Checking wget "
 echo "# ================= #"


### PR DESCRIPTION
Switch from .py to .sh checkout script for the travis-ci tests

Current test state: test fail because during cmsRun step/ python step some of the files are not found. 
Possible issue: with test_built.sh, need to `scramb` once again after the checkout script call.

TODO for everyone: nothing

TODO for me after pull: 
1) change in test_built.sh line `curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/tests_short/Skimming/scripts/${CHECKOUTSCRIPT}` to `curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/master/Skimming/scripts/${CHECKOUTSCRIPT}`
2) add `scram b -j 4 -v` after the chckout block