### PR TITLE
Making Kappa ready for CMSSW92X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: cpp
 services:
   - docker
 env:
-  #- TEST_CMSSW_VERSION=CMSSW_8_0_26_patch1 SCRAM_ARCH=slc6_amd64_gcc530 CHECKOUTSCRIPT=checkoutCmssw80xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
+  - TEST_CMSSW_VERSION=CMSSW_9_2_4 SCRAM_ARCH=slc6_amd64_gcc530 CHECKOUTSCRIPT=checkoutCmssw92xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
+  - TEST_CMSSW_VERSION=CMSSW_8_0_26_patch1 SCRAM_ARCH=slc6_amd64_gcc530 CHECKOUTSCRIPT=checkoutCmssw80xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
   - TEST_CMSSW_VERSION=CMSSW_7_6_3 SCRAM_ARCH=slc6_amd64_gcc493 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=true
   #- TEST_CMSSW_VERSION=CMSSW_5_3_29 SCRAM_ARCH=slc6_amd64_gcc472 CHECKOUTSCRIPT=checkoutCmssw76xPackagesForSkimming.sh SKIMMING_SCRIPT=Kappa/Skimming/higgsTauTau/kSkimming_run2_cfg.py ADDITIONAL_OUTPUT=false
   # skim_tutorial1_basic.py - checkoutDummy.sh and checkoutTauRefit.py are not available

--- a/Producers/interface/KPatTauProducer.h
+++ b/Producers/interface/KPatTauProducer.h
@@ -15,7 +15,7 @@
 #include "../../Producers/interface/Consumes.h"
 #include "boost/functional/hash.hpp"
 
-#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
+#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
 #include "RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h"
 #endif
 
@@ -82,7 +82,7 @@ protected:
 		{
 			out.floatDiscriminators[discriminator->second] = in.tauID(discriminator->first);
 		}
-#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
+#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
 		for(auto variable = extraTaufloatmap[names[0]].begin();  variable!= extraTaufloatmap[names[0]].end(); variable++)
 		{  
 			if (variable->first == EXTRATAUFLOATS::decayDistX ) out.floatDiscriminators[variable->second] = in.flightLength().x();
@@ -155,7 +155,7 @@ public:
 			binaryDiscrBlacklist[names[i]] = pset.getParameter< std::vector<std::string> >("binaryDiscrBlacklist");
 			floatDiscrWhitelist[names[i]] = pset.getParameter< std::vector<std::string> >("floatDiscrWhitelist");
 			extrafloatDiscrlist[names[i]] = pset.getUntrackedParameter< std::vector<std::string> >("extrafloatDiscrlist", std::vector<std::string>(0) );
-#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
+#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION < 21) || (CMSSW_MAJOR_VERSION < 8 )
 			if (extrafloatDiscrlist[names[i]].size() > 0)
 				std::cout << "Warining: extrafloatDiscrlist only available in CMSSW_8_0_21 or new" << std::endl;
 #endif
@@ -246,7 +246,7 @@ virtual bool acceptSingle(const SingleInputType &in) override
 						std::cout << "Float tau discriminator " << ": " << tauID.first << std::endl;
 				}
 			}
-#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) && CMSSW_REVISION < 28 || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
+#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
 			for (auto extrafloatDiscr : extrafloatDiscrlist[names[i]]){
 				EXTRATAUFLOATS add_value = string_to_extraTaufloats(extrafloatDiscr);
 				if (add_value != EXTRATAUFLOATS::UNKNOWN){
@@ -271,7 +271,7 @@ private:
 	}
 	std::map<std::string, std::vector<std::string> > preselectionDiscr;
 	std::map<std::string, std::vector<std::string> > binaryDiscrWhitelist, binaryDiscrBlacklist, floatDiscrWhitelist, floatDiscrBlacklist, extrafloatDiscrlist;
-#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
+#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
 	TauIdMVAAuxiliaries clusterVariables_;
 	enum class EXTRATAUFLOATS : int
 	{

--- a/Producers/interface/KPatTauProducer.h
+++ b/Producers/interface/KPatTauProducer.h
@@ -15,7 +15,7 @@
 #include "../../Producers/interface/Consumes.h"
 #include "boost/functional/hash.hpp"
 
-#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
+#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
 #include "RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h"
 #endif
 
@@ -82,7 +82,7 @@ protected:
 		{
 			out.floatDiscriminators[discriminator->second] = in.tauID(discriminator->first);
 		}
-#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
+#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
 		for(auto variable = extraTaufloatmap[names[0]].begin();  variable!= extraTaufloatmap[names[0]].end(); variable++)
 		{  
 			if (variable->first == EXTRATAUFLOATS::decayDistX ) out.floatDiscriminators[variable->second] = in.flightLength().x();
@@ -155,7 +155,7 @@ public:
 			binaryDiscrBlacklist[names[i]] = pset.getParameter< std::vector<std::string> >("binaryDiscrBlacklist");
 			floatDiscrWhitelist[names[i]] = pset.getParameter< std::vector<std::string> >("floatDiscrWhitelist");
 			extrafloatDiscrlist[names[i]] = pset.getUntrackedParameter< std::vector<std::string> >("extrafloatDiscrlist", std::vector<std::string>(0) );
-#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION < 21) || (CMSSW_MAJOR_VERSION < 8 )
+#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
 			if (extrafloatDiscrlist[names[i]].size() > 0)
 				std::cout << "Warining: extrafloatDiscrlist only available in CMSSW_8_0_21 or new" << std::endl;
 #endif
@@ -246,7 +246,7 @@ virtual bool acceptSingle(const SingleInputType &in) override
 						std::cout << "Float tau discriminator " << ": " << tauID.first << std::endl;
 				}
 			}
-#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
+#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) && CMSSW_REVISION < 28 || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
 			for (auto extrafloatDiscr : extrafloatDiscrlist[names[i]]){
 				EXTRATAUFLOATS add_value = string_to_extraTaufloats(extrafloatDiscr);
 				if (add_value != EXTRATAUFLOATS::UNKNOWN){
@@ -271,7 +271,7 @@ private:
 	}
 	std::map<std::string, std::vector<std::string> > preselectionDiscr;
 	std::map<std::string, std::vector<std::string> > binaryDiscrWhitelist, binaryDiscrBlacklist, floatDiscrWhitelist, floatDiscrBlacklist, extrafloatDiscrlist;
-#if (CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0)
+#if ((CMSSW_MAJOR_VERSION == 8 && CMSSW_MINOR_VERSION == 0 && CMSSW_REVISION >= 21 && CMSSW_REVISION < 28) || (CMSSW_MAJOR_VERSION >= 8 && CMSSW_MINOR_VERSION > 0))
 	TauIdMVAAuxiliaries clusterVariables_;
 	enum class EXTRATAUFLOATS : int
 	{

--- a/Producers/interface/KTriggerObjectStandaloneProducer.h
+++ b/Producers/interface/KTriggerObjectStandaloneProducer.h
@@ -283,7 +283,9 @@ protected:
 		out.toIdxFilter.resize(toMetadata->toFilter.size()); // the idx of this vector corresponds to one common trigger filter ojbect 
 		for(auto obj : in)
 		{
+#if (CMSSW_MAJOR_VERSION >= 9)
 			obj.unpackFilterLabels( *event_, *triggerBitsHandle_);
+#endif
 			std::vector<int>  akt_filter_indices = getFilterIndices(obj.filterLabels());
 			if (akt_filter_indices.empty())
 			  continue;

--- a/Producers/python/KTuple_cff.py
+++ b/Producers/python/KTuple_cff.py
@@ -104,16 +104,10 @@ kappaTupleDefaultsBlock = cms.PSet(
 		rename_blacklist = cms.vstring(),
 	),
 
-	TriggerObjects = cms.PSet(kappaNoRegEx,
-		hltTag = cms.InputTag("hltTriggerSummaryAOD"),
-		triggerObjects = cms.vstring(),
-	),
-
 	TriggerObjectStandalone = cms.PSet(kappaNoRegEx, kappaNoCut,
 			metfilterbits = cms.InputTag("TriggerResults"),
 			metfilterbitslist = cms.vstring(),
 			bits = cms.InputTag("TriggerResults","","HLT"),
-			objects = cms.InputTag("slimmedPatTrigger"),
 			prescales = cms.InputTag("patTrigger"),
 		triggerObjects = cms.PSet(
 			src = cms.InputTag("slimmedPatTrigger"),

--- a/Producers/python/KTuple_cff.py
+++ b/Producers/python/KTuple_cff.py
@@ -110,13 +110,13 @@ kappaTupleDefaultsBlock = cms.PSet(
 	),
 
 	TriggerObjectStandalone = cms.PSet(kappaNoRegEx, kappaNoCut,
-			metfilterbits = cms.InputTag("TriggerResults", "", "PAT"),
+			metfilterbits = cms.InputTag("TriggerResults"),
 			metfilterbitslist = cms.vstring(),
 			bits = cms.InputTag("TriggerResults","","HLT"),
-			objects = cms.InputTag("selectedPatTrigger"),
+			objects = cms.InputTag("slimmedPatTrigger"),
 			prescales = cms.InputTag("patTrigger"),
 		triggerObjects = cms.PSet(
-			src = cms.InputTag("selectedPatTrigger"),
+			src = cms.InputTag("slimmedPatTrigger"),
 			)
 	),
 	Tracks = cms.PSet(kappaNoRename,

--- a/Skimming/data/datasets.json
+++ b/Skimming/data/datasets.json
@@ -1855,6 +1855,21 @@
     "scenario": "PromptRecov3", 
     "xsec": 1.0
   }, 
+  "DoubleEG_Run2017B_23Jun2017v1_13TeV_MINIAOD": {
+    "campaign": "Run2017B", 
+    "data": true, 
+    "dbs": "/DoubleEG/Run2017B-23Jun2017-v1/MINIAOD", 
+    "energy": "13", 
+    "extension": "", 
+    "format": "MINIAOD", 
+    "generator": "", 
+    "globalTag": "92X_dataRun2_v2", 
+    "inputDBS": "global", 
+    "n_events_generated": "7764487", 
+    "n_files": "110", 
+    "process": "DoubleEG", 
+    "scenario": "23Jun2017v1"
+  }, 
   "DoubleElectron_Run2011A_16Jan2012v1_7TeV_AOD": {
     "campaign": "Run2011A", 
     "data": true, 
@@ -2820,6 +2835,21 @@
     "process": "DoubleMuon", 
     "scenario": "PromptRecov3", 
     "xsec": 1.0
+  }, 
+  "DoubleMuon_Run2017B_23Jun2017v1_13TeV_MINIAOD": {
+    "campaign": "Run2017B", 
+    "data": true, 
+    "dbs": "/DoubleMuon/Run2017B-23Jun2017-v1/MINIAOD", 
+    "energy": "13", 
+    "extension": "", 
+    "format": "MINIAOD", 
+    "generator": "", 
+    "globalTag": "92X_dataRun2_v2", 
+    "inputDBS": "global", 
+    "n_events_generated": "2123034", 
+    "n_files": "27", 
+    "process": "DoubleMuon", 
+    "scenario": "23Jun2017v1"
   }, 
   "EWKWMinus2JetsWToLNuM50_RunIIFall15MiniAODv2_PU25nsData2015v1_13TeV_MINIAOD_madgraph-pythia8": {
     "Fall15": [
@@ -6828,6 +6858,21 @@
     "process": "MuonEG", 
     "scenario": "PromptRecov3", 
     "xsec": 1.0
+  }, 
+  "MuonEG_Run2017B_23Jun2017v1_13TeV_MINIAOD": {
+    "campaign": "Run2017B", 
+    "data": true, 
+    "dbs": "/MuonEG/Run2017B-23Jun2017-v1/MINIAOD", 
+    "energy": "13", 
+    "extension": "", 
+    "format": "MINIAOD", 
+    "generator": "", 
+    "globalTag": "92X_dataRun2_v2", 
+    "inputDBS": "global", 
+    "n_events_generated": "582555", 
+    "n_files": "12", 
+    "process": "MuonEG", 
+    "scenario": "23Jun2017v1"
   }, 
   "QCD_RunIIFall15MiniAODv2_PU25nsData2015v1_13TeV_MINIAOD_pythia8": {
     "Fall15": [
@@ -12221,6 +12266,21 @@
     "scenario": "PromptRecov3", 
     "xsec": 1.0
   }, 
+  "SingleElectron_Run2017B_23Jun2017v1_13TeV_MINIAOD": {
+    "campaign": "Run2017B", 
+    "data": true, 
+    "dbs": "/SingleElectron/Run2017B-23Jun2017-v1/MINIAOD", 
+    "energy": "13", 
+    "extension": "", 
+    "format": "MINIAOD", 
+    "generator": "", 
+    "globalTag": "92X_dataRun2_v2", 
+    "inputDBS": "global", 
+    "n_events_generated": "7688359", 
+    "n_files": "95", 
+    "process": "SingleElectron", 
+    "scenario": "23Jun2017v1"
+  }, 
   "SingleMu_Run2011A_May10ReRecov1_7TeV_AOD": {
     "campaign": "Run2011A", 
     "data": true, 
@@ -12779,6 +12839,21 @@
     "process": "SingleMuon", 
     "scenario": "PromptRecov3", 
     "xsec": 1.0
+  }, 
+  "SingleMuon_Run2017B_23Jun2017v1_13TeV_MINIAOD": {
+    "campaign": "Run2017B", 
+    "data": true, 
+    "dbs": "/SingleMuon/Run2017B-23Jun2017-v1/MINIAOD", 
+    "energy": "13", 
+    "extension": "", 
+    "format": "MINIAOD", 
+    "generator": "", 
+    "globalTag": "92X_dataRun2_v2", 
+    "inputDBS": "global", 
+    "n_events_generated": "19500603", 
+    "n_files": "209", 
+    "process": "SingleMuon", 
+    "scenario": "23Jun2017v1"
   }, 
   "TTHHToTauTauM110_Summer12_PUS10_8TeV_AODSIM_pythia6": {
     "campaign": "Summer12", 
@@ -13907,6 +13982,21 @@
     "process": "Tau", 
     "scenario": "PromptRecov3", 
     "xsec": 1.0
+  }, 
+  "Tau_Run2017B_23Jun2017v1_13TeV_MINIAOD": {
+    "campaign": "Run2017B", 
+    "data": true, 
+    "dbs": "/Tau/Run2017B-23Jun2017-v1/MINIAOD", 
+    "energy": "13", 
+    "extension": "", 
+    "format": "MINIAOD", 
+    "generator": "", 
+    "globalTag": "92X_dataRun2_v2", 
+    "inputDBS": "global", 
+    "n_events_generated": "6173967", 
+    "n_files": "74", 
+    "process": "Tau", 
+    "scenario": "23Jun2017v1"
   }, 
   "Tbar_Fall11_PUS6_7TeV_AODSIM_powheg-tauola": {
     "campaign": "Fall11", 

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -178,6 +178,9 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	if not isEmbedded and "Spring16" in str(process.kappaTuple.TreeInfo.parameters.campaign):
 		# adds for each HLT Trigger wich contains "Tau" or "tau" in the name a Filter object named "l1extratauccolltection"
 		process.kappaTuple.TriggerObjectStandalone.l1extratauJetSource = cms.untracked.InputTag("l1extraParticles","IsoTau","RECO")
+	
+	if not tools.is_above_cmssw_version([9]):
+		process.kappaTuple.TriggerObjectStandalone.triggerObjects = cms.InputTag("selectedPatTrigger")
 
 	process.kappaTuple.active += cms.vstring('BeamSpot')
 	if tools.is_above_cmssw_version([7,6]):

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -141,7 +141,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.kappaTuple.active += cms.vstring('TriggerObjectStandalone')
 
 	# setup BadPFMuonFilter and BadChargedCandidateFilter
-	if tools.is_above_cmssw_version([8]) and not tools.is_above_cmssw_version([8]): 
+	if tools.is_above_cmssw_version([8]) and not tools.is_above_cmssw_version([9]): 
 		process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
 		process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
 		process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -442,11 +442,12 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 	process.load("VertexRefit.TauRefit.AdvancedRefitVertexProducer_cfi")
 	
-	process.AdvancedRefitVertexBSProducer.srcElectrons = cms.InputTag(electrons)
-	process.AdvancedRefitVertexBSProducer.srcMuons = cms.InputTag(muons)
-	process.AdvancedRefitVertexBSProducer.srcTaus = cms.InputTag(taus)
-	process.AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(electrons, muons, taus)
-	process.p *= (process.AdvancedRefitVertexBS)
+	if tools.is_above_cmssw_version([7,6]) and not tools.is_above_cmssw_version([9]):
+		process.AdvancedRefitVertexBSProducer.srcElectrons = cms.InputTag(electrons)
+		process.AdvancedRefitVertexBSProducer.srcMuons = cms.InputTag(muons)
+		process.AdvancedRefitVertexBSProducer.srcTaus = cms.InputTag(taus)
+		process.AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(electrons, muons, taus)
+		process.p *= (process.AdvancedRefitVertexBS)
 
 	process.AdvancedRefitVertexNoBSProducer.srcElectrons = cms.InputTag(electrons)
 	process.AdvancedRefitVertexNoBSProducer.srcMuons = cms.InputTag(muons)
@@ -456,13 +457,14 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	process.kappaTuple.RefitVertex.whitelist = cms.vstring('AdvancedRefitVertexBS', 'AdvancedRefitVertexNoBS')
 
-	if tools.is_above_cmssw_version([7,6]):
+	if tools.is_above_cmssw_version([7,6]) and not tools.is_above_cmssw_version([9]):
 		process.kappaTuple.RefitVertex.AdvancedRefittedVerticesBS = cms.PSet(src=cms.InputTag("AdvancedRefitVertexBSProducer"))
 		process.AdvancedRefitVertexBSProducer.srcElectrons = cms.InputTag(electrons)
 		process.AdvancedRefitVertexBSProducer.srcMuons = cms.InputTag(muons)
 		process.AdvancedRefitVertexBSProducer.srcTaus = cms.InputTag(taus)
 		process.AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(electrons, muons, taus)
 
+	if tools.is_above_cmssw_version([7,6]):
 		process.kappaTuple.RefitVertex.AdvancedRefittedVerticesNoBS = cms.PSet(src=cms.InputTag("AdvancedRefitVertexNoBSProducer"))
 		process.AdvancedRefitVertexNoBSProducer.srcElectrons = cms.InputTag(electrons)
 		process.AdvancedRefitVertexNoBSProducer.srcMuons = cms.InputTag(muons)

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -113,7 +113,6 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	data = datasetsHelper.isData(nickname)
 	isEmbedded = datasetsHelper.isEmbedded(nickname)
-	isreHLT = datasetsHelper.isreHLT(nickname)
 	print nickname
 	#####miniaod = datasetsHelper.isMiniaod(nickname) not used anymore, since everything is MiniAOD now
 	process.kappaTuple.TreeInfo.parameters= datasetsHelper.getTreeInfo(nickname, globaltag, kappaTag)
@@ -123,9 +122,6 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	# General configuration
 	if tools.is_above_cmssw_version([7,4]):
 		process.kappaTuple.Info.pileUpInfoSource = cms.InputTag("slimmedAddPileupInfo")
-	if isreHLT:
-		process.kappaTuple.Info.hltSource = cms.InputTag("TriggerResults", "", "HLT2")
-		process.kappaTuple.Info.l1Source = cms.InputTag("")
 	if isSignal:
 		process.kappaTuple.Info.lheSource = cms.InputTag("source")
 
@@ -145,7 +141,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	process.kappaTuple.active += cms.vstring('TriggerObjectStandalone')
 
 	# setup BadPFMuonFilter and BadChargedCandidateFilter
-	if tools.is_above_cmssw_version([8]):
+	if tools.is_above_cmssw_version([8]) and not tools.is_above_cmssw_version([8]): 
 		process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
 		process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
 		process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")
@@ -163,27 +159,23 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 			process.badGlobalMuonTaggerMAOD.taggingMode = cms.bool(True)
 			process.cloneGlobalMuonTaggerMAOD.taggingMode = cms.bool(True)
 
-			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter", "BadPFMuonFilter", "badGlobalMuonTaggerMAOD", "cloneGlobalMuonTaggerMAOD")
-		else:
-			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter","BadPFMuonFilter")
+#			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter", "BadPFMuonFilter", "badGlobalMuonTaggerMAOD", "cloneGlobalMuonTaggerMAOD")
+#		else:
+#			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter","BadPFMuonFilter")
 
 	if isEmbedded:
 		process.kappaTuple.TriggerObjectStandalone.metfilterbits = cms.InputTag("TriggerResults", "", "SIMembedding")
 		process.kappaTuple.Info.hltSource = cms.InputTag("TriggerResults", "", "SIMembedding")
 	elif data:
-		if "03Feb2017" in str(process.kappaTuple.TreeInfo.parameters.scenario):
+		if tools.is_above_cmssw_version([9]):
+			process.kappaTuple.Info.hltSource = cms.InputTag("TriggerResults", "", "HLT")
+			#process.kappaTuple.TriggerObjectStandalone.bits = cms.InputTag("TriggerResults", "", "RECO")
+		elif "03Feb2017" in str(process.kappaTuple.TreeInfo.parameters.scenario):
 			process.kappaTuple.TriggerObjectStandalone.metfilterbits = cms.InputTag("TriggerResults", "", "PAT")
 		else:
 			process.kappaTuple.TriggerObjectStandalone.metfilterbits = cms.InputTag("TriggerResults", "", "RECO")
-
-	#if "reHLT" in datasetsHelper.get_campaign(nickname):
-	#	process.kappaTuple.TriggerObjectStandalone.bits = cms.InputTag("TriggerResults", "", "HLT2")
-	#if not "reHLT" in datasetsHelper.get_campaign(nickname) and not isEmbedded:
-	#	# adds for each HLT Trigger wich contains "Tau" or "tau" in the name a Filter object named "l1extratauccolltection"
-	#	process.kappaTuple.TriggerObjectStandalone.l1extratauJetSource = cms.untracked.InputTag("l1extraParticles","IsoTau","RECO")
-	if isreHLT:
-		process.kappaTuple.TriggerObjectStandalone.bits = cms.InputTag("TriggerResults", "", "HLT2")
-	elif not isEmbedded and "Spring16" in str(process.kappaTuple.TreeInfo.parameters.campaign):
+			process.kappaTuple.Info.hltSource = cms.InputTag("TriggerResults", "", "RECO")
+	if not isEmbedded and "Spring16" in str(process.kappaTuple.TreeInfo.parameters.campaign):
 		# adds for each HLT Trigger wich contains "Tau" or "tau" in the name a Filter object named "l1extratauccolltection"
 		process.kappaTuple.TriggerObjectStandalone.l1extratauJetSource = cms.untracked.InputTag("l1extraParticles","IsoTau","RECO")
 
@@ -245,16 +237,19 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	#process.kappaTuple.packedPFCandidates.packedPFCandidates = cms.PSet(src = cms.InputTag("packedPFCandidates"))
 
 	jetCollectionPuppi = "slimmedJetsPuppi"
-	if tools.is_above_cmssw_version([8]):
+	if tools.is_above_cmssw_version([9]):
+		jetCollection = "slimmedJets"
+	elif tools.is_above_cmssw_version([8]):
 		from RecoMET.METPUSubtraction.jet_recorrections import recorrectJets
 		#from RecoMET.METPUSubtraction.jet_recorrections import loadLocalSqlite
 		#loadLocalSqlite(process, sqliteFilename = "Spring16_25nsV6_DATA.db" if data else "Spring16_25nsV6_MC.db",
 		#                         tag = 'JetCorrectorParametersCollection_Spring16_25nsV6_DATA_AK4PF' if data else 'JetCorrectorParametersCollection_Spring16_25nsV6_MC_AK4PF')
 		recorrectJets(process, isData=data)
+		jetCollection = "patJetsReapplyJEC"
 	else:
 		from RecoMET.METPUSubtraction.localSqlite import recorrectJets
 		recorrectJets(process, isData=data)
-	jetCollection = "patJetsReapplyJEC"
+		jetCollection = "patJetsReapplyJEC"
 
 	## ------------------------------------------------------------------------
 
@@ -477,7 +472,9 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	## Standard MET and GenMet from pat::MET
 	process.kappaTuple.active += cms.vstring('PatMET')
-	if tools.is_above_cmssw_version([8,0,14]):
+	if tools.is_above_cmssw_version([9]):
+		pass
+	elif tools.is_above_cmssw_version([8,0,14]):
 		from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 		runMetCorAndUncFromMiniAOD(process, isData=data  )
 		process.kappaTuple.PatMET.met = cms.PSet(src=cms.InputTag("slimmedMETs", "", "KAPPA"))
@@ -486,23 +483,24 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 	#process.kappaTuple.PatMET.pfmetT1 = cms.PSet(src=cms.InputTag("patpfMETT1"))
 	process.kappaTuple.PatMET.metPuppi = cms.PSet(src=cms.InputTag("slimmedMETsPuppi"))
 
-	## Write MVA MET to KMETs
-	process.kappaTuple.active += cms.vstring('PatMETs')
-	# new MVA MET
-	from RecoMET.METPUSubtraction.MVAMETConfiguration_cff import runMVAMET
-	runMVAMET( process, jetCollectionPF = jetCollection)
-	process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
-	process.MVAMET.srcLeptons  = cms.VInputTag(muons, electrons, taus) # to produce all possible combinations
-	process.MVAMET.requireOS = cms.bool(False)
-	if tools.is_above_cmssw_version([8,0]) and isEmbedded:
-		process.MVAMET.srcMETs = cms.VInputTag(
-			cms.InputTag("slimmedMETs", "", "MERGE"),
-			cms.InputTag("patpfTrackMET"),
-			cms.InputTag("patpfNoPUMET"),
-			cms.InputTag("patpfPUCorrectedMET"),
-			cms.InputTag("patpfPUMET"),
-			cms.InputTag("slimmedMETsPuppi", "", "MERGE")
-			)
+	if not tools.is_above_cmssw_version([9]):
+		## Write MVA MET to KMETs
+		process.kappaTuple.active += cms.vstring('PatMETs')
+		# new MVA MET
+		from RecoMET.METPUSubtraction.MVAMETConfiguration_cff import runMVAMET
+		runMVAMET( process, jetCollectionPF = jetCollection)
+		process.kappaTuple.PatMETs.MVAMET = cms.PSet(src=cms.InputTag("MVAMET", "MVAMET"))
+		process.MVAMET.srcLeptons  = cms.VInputTag(muons, electrons, taus) # to produce all possible combinations
+		process.MVAMET.requireOS = cms.bool(False)
+		if tools.is_above_cmssw_version([8,0]) and isEmbedded:
+			process.MVAMET.srcMETs = cms.VInputTag(
+				cms.InputTag("slimmedMETs", "", "MERGE"),
+				cms.InputTag("patpfTrackMET"),
+				cms.InputTag("patpfNoPUMET"),
+				cms.InputTag("patpfPUCorrectedMET"),
+				cms.InputTag("patpfPUMET"),
+				cms.InputTag("slimmedMETsPuppi", "", "MERGE")
+				)
 
 	## ------------------------------------------------------------------------
 
@@ -541,12 +539,11 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	process.p *= process.nEventsFiltered
 	process.p *= process.nNegEventsFiltered
-	process.kappaTuple.active += cms.vstring('FilterSummary')
 
 	## ------------------------------------------------------------------------
 
 	## if needed adapt output filename
-	process.p *= process.kappaOut
+	process.ep *= process.kappaOut
 	if outputfilename != '':
 		process.kappaTuple.outputFile = cms.string('%s'%outputfilename)
 

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -159,9 +159,9 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 			process.badGlobalMuonTaggerMAOD.taggingMode = cms.bool(True)
 			process.cloneGlobalMuonTaggerMAOD.taggingMode = cms.bool(True)
 
-#			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter", "BadPFMuonFilter", "badGlobalMuonTaggerMAOD", "cloneGlobalMuonTaggerMAOD")
-#		else:
-#			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter","BadPFMuonFilter")
+			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter", "BadPFMuonFilter", "badGlobalMuonTaggerMAOD", "cloneGlobalMuonTaggerMAOD")
+		else:
+			process.kappaTuple.TriggerObjectStandalone.metfilterbitslist = cms.vstring("BadChargedCandidateFilter","BadPFMuonFilter")
 
 	if isEmbedded:
 		process.kappaTuple.TriggerObjectStandalone.metfilterbits = cms.InputTag("TriggerResults", "", "SIMembedding")

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -544,6 +544,7 @@ def getBaseConfig( globaltag= 'START70_V7::All',
 
 	process.p *= process.nEventsFiltered
 	process.p *= process.nNegEventsFiltered
+	process.kappaTuple.active += cms.vstring('FilterSummary')
 
 	## ------------------------------------------------------------------------
 

--- a/Skimming/python/KSkimming_template_cfg.py
+++ b/Skimming/python/KSkimming_template_cfg.py
@@ -49,9 +49,9 @@ print "GT from autoCond:", process.GlobalTag.globaltag
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 ## Kappa
-process.load('Kappa.Producers.KTuple_cff')
+from Kappa.Producers.KTuple_cff import kappaTupleDefaultsBlock
 process.kappaTuple = cms.EDAnalyzer('KTuple',
-    process.kappaTupleDefaultsBlock,
+    kappaTupleDefaultsBlock,
     outputFile = cms.string("kappaTuple.root"),
 )
 process.kappaTuple.active = cms.vstring()

--- a/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
@@ -50,8 +50,6 @@ git cms-merge-topic -u ikrav:egm_id_80X_v2
 git cms-merge-topic -u cms-met:fromCMSSW_8_0_20_postICHEPfilter
 git cms-merge-topic cms-met:METRecipe_8020 -u
 git cms-merge-topic cms-met:METRecipe_80X_part2 -u
-sed -i "/produces<edm::PtrVector<reco::Muon>>/a \	  produces<bool>();" RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
-sed -i "/iEvent.put(std::move(out),/a \	iEvent.put(std::auto_ptr<bool>(new bool(found)));" RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
 #packages needed to rerun tau id
 git cms-merge-topic -u cms-tau-pog:CMSSW_8_0_X_tau-pog_miniAOD-backport-tauID
 
@@ -65,7 +63,6 @@ cd $CMSSW_BASE/src/RecoMET/METPUSubtraction/data
 wget https://github.com/macewindu009/MetTools/raw/nicobranch/MVAMET/weightfiles/weightfile.root
 
 cd $CMSSW_BASE/src
-sed "/import\ switchJetCollection/a from\ RecoMET\.METProducers\.METSignificanceParams_cfi\ import\ METSignificanceParams_Data" PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py -i
 git clone https://github.com/artus-analysis/TauRefit.git VertexRefit/TauRefit
 #fetch xml files for Egamma Id from private repository
 git clone https://github.com/ikrav/RecoEgamma-ElectronIdentification.git tempData/RecoEgamma/ElectronIdentification/data
@@ -81,6 +78,15 @@ rm -rf RecoEgamma/ElectronIdentification/data/.git
 #Remove Fireworks and SimGeneral - they are only checked out due to failed merge attempts
 rm -rf Fireworks
 rm -rf SimGeneral
+rm -rf RecoEgamma
+sed -i '/Fireworks/d' .git/info/sparse-checkout
+sed -i '/SimGeneral/d' .git/info/sparse-checkout
+sed -i '/RecoEgamma/d' .git/info/sparse-checkout
+git read-tree -mu HEAD
+# do the sed's afterwards -> bevore, the read-tree fails
+sed -i "/produces<edm::PtrVector<reco::Muon>>/a \	  produces<bool>();" RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
+sed -i "/iEvent.put(std::move(out),/a \	iEvent.put(std::auto_ptr<bool>(new bool(found)));" RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
+sed "/import\ switchJetCollection/a from\ RecoMET\.METProducers\.METSignificanceParams_cfi\ import\ METSignificanceParams_Data" PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py -i
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 

--- a/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw80xPackagesForSkimming.sh
@@ -78,6 +78,9 @@ rm -rf tempData
 
 #Remove the .git folder as it is not needed and contains a lot of useless data
 rm -rf RecoEgamma/ElectronIdentification/data/.git
+#Remove Fireworks and SimGeneral - they are only checked out due to failed merge attempts
+rm -rf Fireworks
+rm -rf SimGeneral
 #Check out Kappa
 git clone https://github.com/KappaAnalysis/Kappa.git
 

--- a/Skimming/scripts/checkoutCmssw92xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw92xPackagesForSkimming.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e # exit on errors
+
+export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+source $VO_CMS_SW_DIR/cmsset_default.sh
+
+scramv1 project CMSSW CMSSW_9_2_4
+cd CMSSW_9_2_4/src
+eval `scramv1 runtime -sh`
+
+
+#cd $CMSSW_BASE/src
+##Electron cutBased Id and MVA Id
+##https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_for_8_0
+##https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#Recipes_for_regular_users_common
+#git cms-addpkg RecoMET/METPUSubtraction
+#git cms-addpkg DataFormats/METReco
+#git cms-addpkg PhysicsTools/PatUtils
+#git cms-addpkg RecoEgamma/ElectronIdentification
+##This needs to be checked out first since there are conflicts with MVA MET otherwise and then 63 packages are checked out...
+#git cms-merge-topic -u ikrav:egm_id_80X_v2
+## additional metfilters
+#git cms-merge-topic -u cms-met:fromCMSSW_8_0_20_postICHEPfilter
+#git cms-merge-topic cms-met:METRecipe_8020 -u
+#git cms-merge-topic cms-met:METRecipe_80X_part2 -u
+#sed -i "/produces<edm::PtrVector<reco::Muon>>/a \	  produces<bool>();" RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
+#sed -i "/iEvent.put(std::move(out),/a \	iEvent.put(std::auto_ptr<bool>(new bool(found)));" RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
+##packages needed to rerun tau id
+#git cms-merge-topic -u cms-tau-pog:CMSSW_8_0_X_tau-pog_miniAOD-backport-tauID
+#
+##correct jet corrections for mvamet
+#git cms-merge-topic -u cms-met:METRecipe_8020
+##Mvamet package based on Summer16 Training
+#git cms-merge-topic -u macewindu009:mvamet8026
+##copy training weightfile
+#mkdir $CMSSW_BASE/src/RecoMET/METPUSubtraction/data
+#cd $CMSSW_BASE/src/RecoMET/METPUSubtraction/data
+#wget https://github.com/macewindu009/MetTools/raw/nicobranch/MVAMET/weightfiles/weightfile.root
+#
+#cd $CMSSW_BASE/src
+#sed "/import\ switchJetCollection/a from\ RecoMET\.METProducers\.METSignificanceParams_cfi\ import\ METSignificanceParams_Data" PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py -i
+git clone https://github.com/artus-analysis/TauRefit.git VertexRefit/TauRefit
+#fetch xml files for Egamma Id from private repository
+#git clone https://github.com/ikrav/RecoEgamma-ElectronIdentification.git tempData/RecoEgamma/ElectronIdentification/data
+#cd $CMSSW_BASE/src/tempData/RecoEgamma/ElectronIdentification/data
+#git checkout egm_id_80X_v1
+#cd $CMSSW_BASE/src/tempData/
+#cp -r * $CMSSW_BASE/src
+#cd $CMSSW_BASE/src
+#rm -rf tempData
+#
+##Remove the .git folder as it is not needed and contains a lot of useless data
+#rm -rf RecoEgamma/ElectronIdentification/data/.git
+#Check out Kappa
+git clone https://github.com/KappaAnalysis/Kappa.git
+
+scram b -j 4

--- a/test_build.sh
+++ b/test_build.sh
@@ -169,7 +169,7 @@ echo "# ================= #"
 echo "# Download checkout script for Kappa"
 echo "# ================= #"
     mkdir -p /home/build && cd /home/build
-    curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/master/Skimming/scripts/${CHECKOUTSCRIPT}
+    curl -O https://raw.githubusercontent.com/KappaAnalysis/Kappa/CMSSW92X/Skimming/scripts/${CHECKOUTSCRIPT}
     chmod +x ${CHECKOUTSCRIPT}
     cat ${CHECKOUTSCRIPT}
     set -x


### PR DESCRIPTION
Dear all,

after all a few changes had to be made to get Kappa Running on CMSSW. This is especially due to the TriggerObjectStandalone Collection that had some changes. They should be backward-compatible, but I would leave that to the automated tests complaining.

MVAMET is deactivated since there's no CMSSW9 training yet.

Also, the re-correction of jets is deactivated. As soon as there are relevant new JECs we should change that again. The reason is just that we used a module from the MVAMET implementation to re-correct the jets.

The refitted vertex does run. However if not totally necessary we should think about dropping it: Runtime-Wise it is the dominant module, by far: out of 0.166 s/event 0.15 s/event are due to the AdvancedRefitVertexBSProducer and AdvancedRefitVertexNoBSProducer producers on a 2017B SingleElectron Data file.

@greyxray is it a lot of work to extend the automated tests to the 92X release and run the old ones on this branch? I think nothing should change in the old releases, but this has to be proven.